### PR TITLE
Null check for synchronous calls

### DIFF
--- a/src/main/java/com/cloudbees/groovy/cps/impl/Caller.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/Caller.java
@@ -29,7 +29,7 @@ public class Caller {
      */
     public static boolean isAsynchronous(Object receiver, String method, Object... args) {
         Info i = store.get();
-        return receiver==i.receiver.get() && method.equals(i.method) && arrayShallowEquals(i.args, args);
+        return i.receiver != null && receiver==i.receiver.get() && method.equals(i.method) && arrayShallowEquals(i.args, args);
     }
 
     private static boolean arrayShallowEquals(Reference<Object>[] a, Object[] b) {
@@ -42,17 +42,17 @@ public class Caller {
 
     public static boolean isAsynchronous(Object receiver, String method) {
         Info i = store.get();
-        return receiver==i.receiver.get() && method.equals(i.method) && i.args.length==0;
+        return i.receiver != null && receiver==i.receiver.get() && method.equals(i.method) && i.args.length==0;
     }
 
     public static boolean isAsynchronous(Object receiver, String method, Object arg1) {
         Info i = store.get();
-        return receiver==i.receiver.get() && method.equals(i.method) && i.args.length==1 && i.args[0].get()==arg1;
+        return i.receiver != null && receiver==i.receiver.get() && method.equals(i.method) && i.args.length==1 && i.args[0].get()==arg1;
     }
 
     public static boolean isAsynchronous(Object receiver, String method, Object arg1, Object arg2) {
         Info i = store.get();
-        return receiver==i.receiver.get() && method.equals(i.method) && i.args.length==2 && i.args[0].get()==arg1 && i.args[1].get()==arg2;
+        return i.receiver != null && receiver==i.receiver.get() && method.equals(i.method) && i.args.length==2 && i.args[0].get()==arg1 && i.args[1].get()==arg2;
     }
 
     static class Info {

--- a/src/test/java/com/cloudbees/groovy/cps/impl/CallerTest.java
+++ b/src/test/java/com/cloudbees/groovy/cps/impl/CallerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Jesse Glick.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudbees.groovy.cps.impl;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class CallerTest {
+
+    @Test public void isAsynchronous() {
+        assertFalse(Caller.isAsynchronous("hello", "isEmpty"));
+    }
+
+}


### PR DESCRIPTION
Fixes regression in #2:

```
java.lang.NullPointerException
    at com.cloudbees.groovy.cps.impl.Caller.isAsynchronous(Caller.java:50)
    at com.cloudbees.groovy.cps.impl.Caller$isAsynchronous.call(Unknown Source)
    at com.cloudbees.groovy.cps.CpsDefaultGroovyMethods.each(CpsDefaultGroovyMethods.groovy:24)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.codehaus.groovy.runtime.metaclass.ReflectionMetaMethod.invoke(ReflectionMetaMethod.java:51)
    at org.codehaus.groovy.runtime.metaclass.NewInstanceMetaMethod.invoke(NewInstanceMetaMethod.java:54)
    at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:271)
    at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:53)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
    at jenkins.model.InterruptedBuildAction.summary$_run_closure1.doCall(summary.groovy:6)
```

This seems to have been because `record` was not yet called in this thread, so the initial `Info` had null fields, which used to be OK but now I am calling `i.receiver.get()` rather than merely `i.receiver`.

I struggled hard to make `CallerTest` reproduce the realistic call stack from `CpsDefaultGroovyMethods`, by creating a plain `GroovyShell` and making it run the same script from `CpsTransformerTest.each`, but I could not get it to fail—though the original `each` test would fail, without having modified its source code! (It would claim the sum was 0 rather than 55, as if the `each` loop had not run at all.) I think this is because all the tests run in the same JVM. I tried using a different JVM per test suite, but `CallerTest` still passed. I made sure that the static initializer in `ContinuationGroup` was being called, so that `CpsDefaultGroovyMethods` would be registered in the VM-wide metamodel for `each`, but Groovy insisted on calling the standard version in `DefaultGroovyMethods` directly. (`CpsDefaultGroovyMethods` falls back to this if `isAsynchronous` returns false.) Creating a new test extending `AbstractGroovyCpsTest`, or even copying the minimal parts of that over, did not work at all, I think because various parts of `CpsTransformer` call `each` on various lists. So I gave up and just tested `Caller.isAsynchronous` directly.

@reviewbybees