### PR TITLE
Added a hook to insert a subtype of CpsClosure.

### DIFF
--- a/src/main/groovy/com/cloudbees/groovy/cps/CpsTransformer.groovy
+++ b/src/main/groovy/com/cloudbees/groovy/cps/CpsTransformer.groovy
@@ -16,6 +16,7 @@ import org.codehaus.groovy.control.customizers.CompilationCustomizer
 import org.codehaus.groovy.runtime.powerassert.SourceText
 import org.codehaus.groovy.syntax.Token
 
+import javax.annotation.Nonnull
 import java.lang.annotation.Annotation
 import java.lang.reflect.Modifier
 
@@ -82,7 +83,7 @@ class CpsTransformer extends CompilationCustomizer implements GroovyCodeVisitor 
         super(CompilePhase.CANONICALIZATION)
     }
 
-    public void setConfiguration(TransformerConfiguration config) {
+    public void setConfiguration(@Nonnull TransformerConfiguration config) {
         this.config = config;
     }
 

--- a/src/main/groovy/com/cloudbees/groovy/cps/CpsTransformer.groovy
+++ b/src/main/groovy/com/cloudbees/groovy/cps/CpsTransformer.groovy
@@ -76,9 +76,14 @@ import static org.codehaus.groovy.syntax.Types.*
 class CpsTransformer extends CompilationCustomizer implements GroovyCodeVisitor {
     private int iota=0;
     private SourceUnit sourceUnit;
+    private TransformerConfiguration config = new TransformerConfiguration();
 
     CpsTransformer() {
         super(CompilePhase.CANONICALIZATION)
+    }
+
+    public void setConfiguration(TransformerConfiguration config) {
+        this.config = config;
     }
 
     @Override
@@ -165,6 +170,7 @@ class CpsTransformer extends CompilationCustomizer implements GroovyCodeVisitor 
         /*
               CpsFunction ___cps___N() {
                 Builder b = new Builder(new MethodLocation(...));
+                b.withClosureType(...);
                 return new CpsFunction( << parameters >>, << body: AST tree building code >>);
               }
          */
@@ -181,6 +187,9 @@ class CpsTransformer extends CompilationCustomizer implements GroovyCodeVisitor 
                                             new ConstantExpression(sourceUnit.name)
                                         ))
                                     )))),
+                new ExpressionStatement(
+                        new MethodCallExpression(BUILDER, "withClosureType",
+                                new TupleExpression(new ClassExpression(config.closureType)))),
                 new ReturnStatement(new ConstructorCallExpression(FUNCTION_TYPE, new TupleExpression(params, body)))
             ], new VariableScope())
         )
@@ -582,6 +591,8 @@ class CpsTransformer extends CompilationCustomizer implements GroovyCodeVisitor 
 
     void visitClosureExpression(ClosureExpression exp) {
         makeNode("closure") {
+            loc(exp)
+
             def params = new ListExpression();
 
             // the interpretation of the 'parameters' is messed up. According to ClosureWriter,

--- a/src/main/java/com/cloudbees/groovy/cps/Builder.java
+++ b/src/main/java/com/cloudbees/groovy/cps/Builder.java
@@ -9,6 +9,7 @@ import com.cloudbees.groovy.cps.impl.BreakBlock;
 import com.cloudbees.groovy.cps.impl.ClosureBlock;
 import com.cloudbees.groovy.cps.impl.ConstantBlock;
 import com.cloudbees.groovy.cps.impl.ContinueBlock;
+import com.cloudbees.groovy.cps.impl.CpsClosure;
 import com.cloudbees.groovy.cps.impl.DoWhileBlock;
 import com.cloudbees.groovy.cps.impl.ElvisBlock;
 import com.cloudbees.groovy.cps.impl.ExcrementOperatorBlock;
@@ -52,9 +53,18 @@ import static java.util.Arrays.*;
  */
 public class Builder {
     private MethodLocation loc;
+    private Class<? extends CpsClosure> closureType;
 
     public Builder(MethodLocation loc) {
         this.loc = loc;
+    }
+
+    /**
+     * Overrides the actual instance type of {@link CpsClosure} to be created.
+     */
+    public Builder withClosureType(Class<? extends CpsClosure> t) {
+        closureType = t;
+        return this;
     }
 
     /**
@@ -143,8 +153,8 @@ public class Builder {
         return b;
     }
 
-    public Block closure(List<String> parameters, Block body) {
-        return new ClosureBlock(parameters,body);
+    public Block closure(int line, List<String> parameters, Block body) {
+        return new ClosureBlock(loc(line),parameters,body,closureType);
     }
 
     public LValueBlock localVariable(String name) {

--- a/src/main/java/com/cloudbees/groovy/cps/TransformerConfiguration.java
+++ b/src/main/java/com/cloudbees/groovy/cps/TransformerConfiguration.java
@@ -1,6 +1,7 @@
 package com.cloudbees.groovy.cps;
 
 import com.cloudbees.groovy.cps.impl.CpsClosure;
+import groovy.lang.Closure;
 import org.codehaus.groovy.ast.ClassNode;
 
 /**
@@ -21,7 +22,7 @@ public class TransformerConfiguration {
         return this;
     }
 
-    public TransformerConfiguration withClosureType(Class c) {
+    public TransformerConfiguration withClosureType(Class<? extends Closure> c) {
         return withClosureType(new ClassNode(c));
     }
 }

--- a/src/main/java/com/cloudbees/groovy/cps/TransformerConfiguration.java
+++ b/src/main/java/com/cloudbees/groovy/cps/TransformerConfiguration.java
@@ -1,0 +1,27 @@
+package com.cloudbees.groovy.cps;
+
+import com.cloudbees.groovy.cps.impl.CpsClosure;
+import org.codehaus.groovy.ast.ClassNode;
+
+/**
+ * Switches that affect the behaviour of {@link CpsTransformer}
+ *
+ * @author Kohsuke Kawaguchi
+ * @see CpsTransformer#setConfiguration(TransformerConfiguration)
+ */
+public class TransformerConfiguration {
+    private ClassNode closureType = new ClassNode(CpsClosure.class);
+
+    public ClassNode getClosureType() {
+        return closureType;
+    }
+
+    public TransformerConfiguration withClosureType(ClassNode closureType) {
+        this.closureType = closureType;
+        return this;
+    }
+
+    public TransformerConfiguration withClosureType(Class c) {
+        return withClosureType(new ClassNode(c));
+    }
+}

--- a/src/main/java/com/cloudbees/groovy/cps/impl/ClosureBlock.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/ClosureBlock.java
@@ -5,6 +5,7 @@ import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 import com.cloudbees.groovy.cps.Next;
 
+import java.lang.reflect.Constructor;
 import java.util.List;
 
 /**
@@ -15,14 +16,32 @@ import java.util.List;
 public class ClosureBlock implements Block {
     private final List<String> parameters;
     private final Block body;
+    // this field would be null if we are deserializing from data saved by old version
+    private final Class<? extends CpsClosure> closureType;
+    private final SourceLocation loc;
 
-    public ClosureBlock(List<String> parameters, Block body) {
+    public ClosureBlock(SourceLocation loc, List<String> parameters, Block body, Class<? extends CpsClosure> closureType) {
+        this.loc = loc;
         this.parameters = parameters;
         this.body = body;
+        this.closureType = closureType;
+    }
+
+    private Class<? extends CpsClosure> closureType() {
+        if (closureType==null)  return CpsClosure.class; // backward compatibility with persisted form
+        return closureType;
     }
 
     public Next eval(Env e, Continuation k) {
-        return k.receive(new CpsClosure(e.closureOwner(), e.getLocalVariable("this"), parameters,body,e));
+        try {
+            Constructor c = closureType().getConstructor(
+                Object.class, Object.class, List.class, Block.class, Env.class
+            );
+            return k.receive(c.newInstance(e.closureOwner(), e.getLocalVariable("this"), parameters,body,e));
+        } catch (Exception x) {
+            return new ContinuationGroup() {}.
+                throwException(e, x, loc, new ReferenceStackTrace());
+        }
     }
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Allow the calling code to use a subtype of `CpsClosure` to customize the behaviour of closure.

This was necessary for Jenkins Workflow plugin to intercept the sleep()
call, which requires adding a declared method on CpsClosure.

See more about this in jenkinsci/workflow-plugin #131.

In anticipation of additional CPS transformer configuration switches in
the future, this change introduces a class that collects such random
switches.