### PR TITLE
ContinuationGroup.asBoolean did not correctly implement Groovy truthiness

### DIFF
--- a/src/main/java/com/cloudbees/groovy/cps/impl/AssertBlock.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/AssertBlock.java
@@ -5,6 +5,7 @@ import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 import com.cloudbees.groovy.cps.Next;
 import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;
+import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 /**
  * assert exp : msg;
@@ -35,7 +36,7 @@ public class AssertBlock implements Block {
         }
 
         public Next jump(Object cond) {
-            if (asBoolean(cond))
+            if (DefaultTypeTransformation.castToBoolean(cond))
                 return k.receive(null);
             else
                 return then(msg, e, fail);

--- a/src/main/java/com/cloudbees/groovy/cps/impl/ContinuationGroup.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/ContinuationGroup.java
@@ -10,7 +10,6 @@ import groovy.lang.MetaMethod;
 import org.codehaus.groovy.reflection.CachedClass;
 import org.codehaus.groovy.reflection.CachedMethod;
 import org.codehaus.groovy.reflection.ReflectionCache;
-import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;
 import org.codehaus.groovy.runtime.callsite.CallSite;
 import org.codehaus.groovy.runtime.metaclass.NewInstanceMetaMethod;
 
@@ -39,19 +38,6 @@ abstract class ContinuationGroup implements Serializable {
 
     public Next then(Block exp, Env e, Continuation k) {
         return new Next(exp,e,k);
-    }
-
-    /**
-     * Casts the value to boolean by following the Groovy semantics.
-     */
-    protected final boolean asBoolean(Object o) {
-        try {
-            return (Boolean) ScriptBytecodeAdapter.asType(o, Boolean.class);
-        } catch (Throwable e) {
-            // TODO: exception handling
-            e.printStackTrace();
-            return false;
-        }
     }
 
     /*TODO: specify the proper owner value (to the script that includes the call site) */

--- a/src/main/java/com/cloudbees/groovy/cps/impl/DoWhileBlock.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/DoWhileBlock.java
@@ -4,6 +4,7 @@ import com.cloudbees.groovy.cps.Block;
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 import com.cloudbees.groovy.cps.Next;
+import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 /**
  * do { ... } while ( ... );
@@ -43,7 +44,7 @@ public class DoWhileBlock implements Block {
         }
 
         public Next loopCond(Object cond) {
-            if (asBoolean(cond)) {
+            if (DefaultTypeTransformation.castToBoolean(cond)) {
                 // loop
                 return top();
             } else {

--- a/src/main/java/com/cloudbees/groovy/cps/impl/ElvisBlock.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/ElvisBlock.java
@@ -4,6 +4,7 @@ import com.cloudbees.groovy.cps.Block;
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 import com.cloudbees.groovy.cps.Next;
+import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 /**
  * x ?: y
@@ -33,7 +34,7 @@ public class ElvisBlock implements Block {
         }
 
         public Next jump(Object cond) {
-            if (asBoolean(cond)) {
+            if (DefaultTypeTransformation.castToBoolean(cond)) {
                 return k.receive(cond);
             } else {
                 return then(falseExp, e, k);

--- a/src/main/java/com/cloudbees/groovy/cps/impl/ForLoopBlock.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/ForLoopBlock.java
@@ -4,6 +4,7 @@ import com.cloudbees.groovy.cps.Block;
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 import com.cloudbees.groovy.cps.Next;
+import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 /**
  * for (e1; e2; e3) { ... body ... }
@@ -41,7 +42,7 @@ public class ForLoopBlock implements Block {
         }
 
         public Next loopCond(Object cond) {
-            if (asBoolean(cond)) {
+            if (DefaultTypeTransformation.castToBoolean(cond)) {
                 // loop
                 return then(body,e,increment);
             } else {

--- a/src/main/java/com/cloudbees/groovy/cps/impl/IfBlock.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/IfBlock.java
@@ -4,6 +4,7 @@ import com.cloudbees.groovy.cps.Block;
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 import com.cloudbees.groovy.cps.Next;
+import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 /**
  * if (...) { ... } else { ... }
@@ -33,7 +34,7 @@ public class IfBlock implements Block {
         }
 
         public Next jump(Object cond) {
-            return then(asBoolean(cond) ? then : els,e,k);
+            return then(DefaultTypeTransformation.castToBoolean(cond) ? then : els,e,k);
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/com/cloudbees/groovy/cps/impl/LogicalOpBlock.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/LogicalOpBlock.java
@@ -4,6 +4,7 @@ import com.cloudbees.groovy.cps.Block;
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 import com.cloudbees.groovy.cps.Next;
+import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 /**
  * Logical operator (&& and ||)
@@ -34,7 +35,7 @@ public class LogicalOpBlock implements Block {
         }
 
         public Next decide(Object lhs) {
-            boolean v = asBoolean(lhs);
+            boolean v = DefaultTypeTransformation.castToBoolean(lhs);
             if (and) {
                 if (!v)     return k.receive(false);    // false && ...
                 else        return then(rhs,e,k);

--- a/src/main/java/com/cloudbees/groovy/cps/impl/WhileBlock.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/WhileBlock.java
@@ -4,6 +4,7 @@ import com.cloudbees.groovy.cps.Block;
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 import com.cloudbees.groovy.cps.Next;
+import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 /**
  * while(...) { ... }
@@ -39,7 +40,7 @@ public class WhileBlock implements Block {
         }
 
         public Next loopCond(Object cond) {
-            if (asBoolean(cond)) {
+            if (DefaultTypeTransformation.castToBoolean(cond)) {
                 // loop
                 return then(body,e,loopHead);
             } else {

--- a/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -379,6 +379,11 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
     }
 
     @Test
+    void ternaryOp3() {
+        assert evalCPS("def x = 'ok'; def y = null; [x ?: 1, y ?: 2]") == ['ok', 2]
+    }
+
+    @Test
     void elvisOp() {
         assert evalCPS("def x=0; return ++x ?: -1")==1;
         assert evalCPS("def x=0; return x++ ?: -1")==-1;


### PR DESCRIPTION
Note that the test does not fail without the main source patch, for reasons unknown, though it does print the stack trace

```
java.lang.NullPointerException
	at com.cloudbees.groovy.cps.impl.ContinuationGroup.asBoolean(ContinuationGroup.java:50)
	at com.cloudbees.groovy.cps.impl.ElvisBlock$ContinuationImpl.jump(ElvisBlock.java:36)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.receive(ContinuationPtr.java:72)
	at com.cloudbees.groovy.cps.impl.LocalVariableBlock$LocalVariable.get(LocalVariableBlock.java:33)
	at com.cloudbees.groovy.cps.LValueBlock$GetAdapter.receive(LValueBlock.java:30)
	at com.cloudbees.groovy.cps.impl.LocalVariableBlock.evalLValue(LocalVariableBlock.java:22)
	at com.cloudbees.groovy.cps.LValueBlock$BlockImpl.eval(LValueBlock.java:55)
	at com.cloudbees.groovy.cps.LValueBlock.eval(LValueBlock.java:16)
	at com.cloudbees.groovy.cps.Next.step(Next.java:58)
	at com.cloudbees.groovy.cps.Next.run(Next.java:49)
	at com.cloudbees.groovy.cps.Next$run.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:112)
	at com.cloudbees.groovy.cps.AbstractGroovyCpsTest.evalCPSonly(AbstractGroovyCpsTest.groovy:55)
	at com.cloudbees.groovy.cps.AbstractGroovyCpsTest.evalCPS(AbstractGroovyCpsTest.groovy:49)
	at com.cloudbees.groovy.cps.AbstractGroovyCpsTest$evalCPS.callCurrent(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:46)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:141)
	at com.cloudbees.groovy.cps.CpsTransformerTest.ternaryOp3(CpsTransformerTest.groovy:383)
```

@reviewbybees esp. @kohsuke