### PR TITLE
Unit test for Closure.rehydrate()

### DIFF
--- a/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -3,6 +3,7 @@ package com.cloudbees.groovy.cps
 import com.cloudbees.groovy.cps.impl.ContinuationGroup
 import com.cloudbees.groovy.cps.impl.CpsCallableInvocation
 import com.cloudbees.groovy.cps.impl.DGMPatcher
+import groovy.transform.NotYetImplemented
 import org.junit.Ignore
 import org.junit.Test
 import org.jvnet.hudson.test.Issue
@@ -622,5 +623,24 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
             [1, 2, 3].each { y -> x+=y; }
             return x;
         """) == 6;
+    }
+
+    @Test
+    @NotYetImplemented
+    void rehydrateClosure() {
+        assert evalCPS('''
+            class MyStrategy {
+                Closure<String> process() {
+                    return {
+                        speak()
+                    }
+                }
+            }
+            String speak() {
+                'from Script instance'
+            }
+            Closure<String> closure = new MyStrategy().process()
+            closure.rehydrate(this, this, this).call()
+        ''') == 'from Script instance';
     }
 }

--- a/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -625,6 +625,7 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
         """) == 6;
     }
 
+    @Issue('https://github.com/cloudbees/groovy-cps/issues/28')
     @Test
     @NotYetImplemented
     void rehydrateClosure() {


### PR DESCRIPTION
Unit test for #28 
Marked as `@NotYetImplemented` as there is no fix yet

rehydrate needed when integrating OOP design in DSL scripts
