### PR TITLE
Unit test for GString with StringWriter closure

### DIFF
--- a/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -378,9 +378,8 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
             String text = 'Foobar';
             String result = """${ w -> w << text}""".toString();
             return result;
-        ''';
-        def cpsResult = evalCPSonly(script);
-        assert cpsResult.getClass() == java.lang.String.class;
+        '''.stripIndent();
+        assert evalCPSonly(script).getClass() == java.lang.String.class;
         assert evalCPS(script) == 'Foobar';
     }
 

--- a/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -3,6 +3,7 @@ package com.cloudbees.groovy.cps
 import com.cloudbees.groovy.cps.impl.ContinuationGroup
 import com.cloudbees.groovy.cps.impl.CpsCallableInvocation
 import com.cloudbees.groovy.cps.impl.DGMPatcher
+import groovy.transform.NotYetImplemented
 import org.junit.Ignore
 import org.junit.Test
 import org.jvnet.hudson.test.Issue
@@ -367,6 +368,20 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
             def x = "foo";
             return "hello ${1+3}=${x}";
 ''')=="hello 4=foo";
+    }
+
+    @Issue('https://github.com/cloudbees/groovy-cps/issues/15')
+    @Test
+    @NotYetImplemented
+    void gstringWithStringWriterClosure() {
+        String script = '''
+            String text = 'Foobar';
+            String result = """${ w -> w << text}""".toString();
+            return result;
+        ''';
+        def cpsResult = evalCPSonly(script);
+        assert cpsResult.getClass() == java.lang.String.class;
+        assert evalCPS(script) == 'Foobar';
     }
 
     @Test


### PR DESCRIPTION
#15

Marked as `@NotYetImplemented` since there is no fix yet

There is an extra assertion to assert for the datatype because of
assertion report lacking that information (the `java.io.StringWriter`
instance is displayed according to its `toString()` representation) which
does not suit the current test where we compare with `java.lang.String`
