### PR TITLE
Fixes #31: Constructor coercion support

### DIFF
--- a/src/main/groovy/com/cloudbees/groovy/cps/CpsTransformer.groovy
+++ b/src/main/groovy/com/cloudbees/groovy/cps/CpsTransformer.groovy
@@ -707,6 +707,7 @@ class CpsTransformer extends CompilationCustomizer implements GroovyCodeVisitor 
         if (ref instanceof VariableExpression /* local variable */
         ||  ref instanceof Parameter) {
             makeNode("localVariable") {
+                loc(exp)
                 literal(exp.name)
             }
         } else

--- a/src/main/java/com/cloudbees/groovy/cps/Builder.java
+++ b/src/main/java/com/cloudbees/groovy/cps/Builder.java
@@ -77,7 +77,7 @@ public class Builder {
     }
 
     private static final Block NULL = new ConstantBlock(null);
-    private static final LValueBlock THIS = new LocalVariableBlock("this");
+    private static final LValueBlock THIS = new LocalVariableBlock(null, "this");
     private static final Block JAVA_THIS = new JavaThisBlock();
 
     public Block null_() {
@@ -163,11 +163,15 @@ public class Builder {
     }
 
     public LValueBlock localVariable(String name) {
-        return new LocalVariableBlock(name);
+        return new LocalVariableBlock(null, name);
+    }
+
+    public LValueBlock localVariable(int line, String name) {
+        return new LocalVariableBlock(loc(line), name);
     }
 
     public Block setLocalVariable(int line, final String name, final Block rhs) {
-        return assign(line,localVariable(name),rhs);
+        return assign(line,localVariable(line, name),rhs);
     }
 
     public Block declareVariable(final Class type, final String name) {
@@ -195,7 +199,7 @@ public class Builder {
      * Assignment operator to a local variable, such as {@code x += 3}
      */
     public Block localVariableAssignOp(int line, String name, String operator, Block rhs) {
-        return setLocalVariable(line, name, functionCall(line, localVariable(name), operator, rhs));
+        return setLocalVariable(line, name, functionCall(line, localVariable(line, name), operator, rhs));
     }
 
     /**

--- a/src/main/java/com/cloudbees/groovy/cps/Env.java
+++ b/src/main/java/com/cloudbees/groovy/cps/Env.java
@@ -3,6 +3,8 @@ package com.cloudbees.groovy.cps;
 import com.cloudbees.groovy.cps.sandbox.Invoker;
 import groovy.lang.Closure;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.List;
 
@@ -16,6 +18,9 @@ public interface Env extends Serializable {
 
     Object getLocalVariable(String name);
     void setLocalVariable(String name, Object value);
+
+    @CheckForNull
+    Class getLocalVariableType(@Nonnull String name);
 
     /**
      * Closure instance or 'this' object that surrounds the currently executing code.

--- a/src/main/java/com/cloudbees/groovy/cps/impl/BlockScopeEnv.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/BlockScopeEnv.java
@@ -13,13 +13,15 @@ import java.util.Map;
 // TODO: should be package local once all the impls move into this class
 public class BlockScopeEnv extends ProxyEnv {
     private final Map<String,Object> locals = new HashMap<String, Object>();
+    private Map<String, Class> types = new HashMap<String, Class>();
 
     public BlockScopeEnv(Env parent) {
         super(parent);
     }
 
     public void declareVariable(Class type, String name) {
-        locals.put(name,null);
+        locals.put(name, null);
+        getTypes().put(name, type);
     }
 
     public Object getLocalVariable(String name) {
@@ -29,9 +31,21 @@ public class BlockScopeEnv extends ProxyEnv {
             return parent.getLocalVariable(name);
     }
 
+    /** Because might deserialize old version of class with null value for field */
+    private Map<String, Class> getTypes() {
+        if (types == null) {
+            this.types = new HashMap<String, Class>();
+        }
+        return this.types;
+    }
+
+    public Class getLocalVariableType(String name) {
+        return (locals.containsKey(name)) ? getTypes().get(name) : parent.getLocalVariableType(name);
+    }
+
     public void setLocalVariable(String name, Object value) {
         if (locals.containsKey(name))
-            locals.put(name, value);
+            locals.put(name,value);
         else
             parent.setLocalVariable(name, value);
     }

--- a/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
@@ -6,7 +6,9 @@ import com.cloudbees.groovy.cps.Next;
 import com.cloudbees.groovy.cps.sandbox.Invoker;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Common part between {@link FunctionCallEnv} and {@link ClosureCallEnv}.
@@ -15,6 +17,7 @@ import java.util.List;
  */
 /*package*/ abstract class CallEnv implements Env {
     private final Continuation returnAddress;
+    private Map<String, Class> types = new HashMap<String, Class>();
 
     /**
      * Caller environment, used for throwing an exception.
@@ -41,6 +44,18 @@ import java.util.List;
         this.callSiteLoc = loc;
         this.invoker = caller==null ? Invoker.INSTANCE : caller.getInvoker();
         assert returnAddress!=null;
+    }
+
+    /** Because might deserialize old version of class with null value for field */
+    protected Map<String, Class> getTypes() {
+        if (types == null) {
+            this.types = new HashMap<String, Class>();
+        }
+        return this.types;
+    }
+
+    public Class getLocalVariableType(String name) {
+        return getTypes().get(name);
     }
 
     /**

--- a/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
@@ -29,6 +29,7 @@ class ClosureCallEnv extends CallEnv {
 
     public void declareVariable(Class type, String name) {
         locals.put(name,null);
+        getTypes().put(name, type);
     }
 
     public Object getLocalVariable(String name) {
@@ -43,6 +44,10 @@ class ClosureCallEnv extends CallEnv {
             locals.put(name, value);
         else
             captured.setLocalVariable(name, value);
+    }
+
+    public Class getLocalVariableType(String name) {
+        return (locals.containsKey(name)) ? getTypes().get(name) : captured.getLocalVariableType(name);
     }
 
     public Object closureOwner() {

--- a/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
@@ -24,7 +24,8 @@ public class FunctionCallEnv extends CallEnv {
     }
 
     public void declareVariable(Class type, String name) {
-        // no-op
+        locals.put(name, null);
+        getTypes().put(name, type);
     }
 
     public Object getLocalVariable(String name) {

--- a/src/main/java/com/cloudbees/groovy/cps/impl/ProxyEnv.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/ProxyEnv.java
@@ -28,6 +28,10 @@ public class ProxyEnv implements Env {
         parent.setLocalVariable(name, value);
     }
 
+    public Class getLocalVariableType(String name) {
+        return parent.getLocalVariableType(name);
+    }
+
     public Object closureOwner() {
         return parent.closureOwner();
     }

--- a/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -138,7 +138,11 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
             return f
         '''.stripIndent()) == new File('/parent', 'name')
 
-        // TODO test for closure env with a File declaration
+        // Test the closure env
+        assert evalCPS('''\
+            def close = {String parent, String name -> [parent, name] as File}
+            return close('/parent', 'name')
+        '''.stripIndent()) == new File('/parent', 'name')
     }
 
     @Test

--- a/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -3,6 +3,7 @@ package com.cloudbees.groovy.cps
 import com.cloudbees.groovy.cps.impl.ContinuationGroup
 import com.cloudbees.groovy.cps.impl.CpsCallableInvocation
 import com.cloudbees.groovy.cps.impl.DGMPatcher
+import groovy.transform.NotYetImplemented
 import org.junit.Ignore
 import org.junit.Test
 import org.jvnet.hudson.test.Issue
@@ -125,6 +126,16 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
         assert evalCPS("""
             new String()
         """)=="";
+    }
+
+    @Issue('https://github.com/cloudbees/groovy-cps/issues/31')
+    @Test
+    @NotYetImplemented
+    void constructorList() {
+        assert evalCPS('''\
+            File f = ['/parent', 'name']
+            return f
+        '''.stripIndent()) == new File('/parent', 'name')
     }
 
     @Test

--- a/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -130,12 +130,15 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
 
     @Issue('https://github.com/cloudbees/groovy-cps/issues/31')
     @Test
-    @NotYetImplemented
     void constructorList() {
+        File f =  ['/parent', 'name'];
+        println(f);
         assert evalCPS('''\
             File f = ['/parent', 'name']
             return f
         '''.stripIndent()) == new File('/parent', 'name')
+
+        // TODO test for closure env with a File declaration
     }
 
     @Test


### PR DESCRIPTION
Fixes #31. Builds on top of https://github.com/cloudbees/groovy-cps/pull/32 by adding support for type-checked list constructors.  Uses the Groovy internal method to do type coercion before storage, and Envs store variable types when the variables are declared.

TODO:
- [x] Enable testcase
- [x] Implementation, including test passes
- [x] Basic test of variable type storage

This should provide the basic implementation and cover main cases.  If there are special cases that need additional work to support, those can be later efforts. 
