### PR TITLE
[JENKINS-34064] DGMPatcher is broken in Groovy 2, so do not try to use it at all

### DIFF
--- a/src/main/java/com/cloudbees/groovy/cps/impl/ContinuationGroup.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/ContinuationGroup.java
@@ -82,9 +82,11 @@ abstract class ContinuationGroup implements Serializable {
 */
     }
 
+    /* TODO JENKINS-34064 does not yet work in Groovy 2:
     static {
         DGMPatcher.init();
     }
+    */
 
     /**
      * Fix up the stack trace of an exception thrown from synchronous code.

--- a/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -437,6 +437,7 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
     /**
      * Testing {@link CpsDefaultGroovyMethods}.
      */
+    @Ignore("TODO JENKINS-34064")
     @Test
     void each() {
         assert evalCPS("""
@@ -615,7 +616,7 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
 
     public static int add(int a, int b) { return a+b; }
 
-
+    @Ignore("TODO JENKINS-34064")
     @Test
     void eachArray() {
         assert evalCPS("""


### PR DESCRIPTION
Until #24 is finished, the trunk versions of this component (including the 1.7 and 1.8 releases) do not work in Groovy 2 and hence Jenkins 2. So basically suppress #23 for now. With this merged and a 1.9 cut, we should be able to release https://github.com/jenkinsci/workflow-cps-plugin/pull/33.

@reviewbybees esp. @kohsuke