### PR TITLE
Fixes #42: Compilation threw NPE on abstract methods

### DIFF
--- a/src/main/groovy/com/cloudbees/groovy/cps/CpsTransformer.groovy
+++ b/src/main/groovy/com/cloudbees/groovy/cps/CpsTransformer.groovy
@@ -127,7 +127,10 @@ class CpsTransformer extends CompilationCustomizer implements GroovyCodeVisitor 
      * Should this method be transformed?
      */
     protected boolean shouldBeTransformed(MethodNode node) {
-        return !node.isSynthetic() && !hasAnnotation(node, NonCPS.class) && !hasAnnotation(node, WorkflowTransformed.class);
+        return !node.isSynthetic() &&
+                !hasAnnotation(node, NonCPS.class) &&
+                !hasAnnotation(node, WorkflowTransformed.class) &&
+                !node.isAbstract();
     }
 
     private boolean hasAnnotation(MethodNode node, Class<? extends Annotation> a) {

--- a/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -664,4 +664,19 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
             new Foo().toString();
         ''')=="xbase"
     }
+
+    @Test
+    @Issue("https://github.com/cloudbees/groovy-cps/issues/42")
+    void abstractMethod() {
+        try {
+            evalCPS("""
+                abstract class Foo {
+                    abstract void run()
+                }
+                def ignoreResult = null
+            """)
+        } catch (NullPointerException e) {
+            fail("Compilation failed")
+        }
+    }
 }


### PR DESCRIPTION
This fix marks abstract methods as nonTransformable
