### PR TITLE
[JENKINS-34064] Groovy 2.x fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>groovy-cps</artifactId>
-  <version>1.7</version>
+  <version>1.8-SNAPSHOT</version>
 
   <name>Groovy CPS Execution</name>
 
@@ -110,7 +110,7 @@
   <scm>
     <connection>scm:git:git@github.com/cloudbees/${project.artifactId}.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/cloudbees/${project.artifactId}.git</developerConnection>
-    <tag>groovy-cps-1.7</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <groovy.version>2.4.11</groovy.version>
   </properties>
 
   <build>
@@ -81,12 +82,18 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
-      <version>2.4.6</version>
+      <version>${groovy.version}</version>
       <!--
         let the user of this library select the right flavor of groovy,
         including groovy vs groovy-all
       -->
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-test</artifactId>
+      <version>${groovy.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
-      <version>1.8.9</version>
+      <version>2.4.6</version>
       <!--
         let the user of this library select the right flavor of groovy,
         including groovy vs groovy-all

--- a/src/main/groovy/com/cloudbees/groovy/cps/CpsDefaultGroovyMethods.groovy
+++ b/src/main/groovy/com/cloudbees/groovy/cps/CpsDefaultGroovyMethods.groovy
@@ -44,6 +44,10 @@ public class CpsDefaultGroovyMethods {
         throw new CpsCallableInvocation(f,null,self,closure);
     }
 
+    public static <T> Iterator<T> each(List<T> iter, Closure closure) {
+        return each((Object)iter,closure);
+    }
+
     public static <T> Iterator<T> each(Iterator<T> iter, Closure closure) {
         if (!Caller.isAsynchronous(iter,"each",closure)
          && !Caller.isAsynchronous(CpsDefaultGroovyMethods.class,"each",iter,closure))

--- a/src/main/groovy/com/cloudbees/groovy/cps/CpsDefaultGroovyMethods.groovy
+++ b/src/main/groovy/com/cloudbees/groovy/cps/CpsDefaultGroovyMethods.groovy
@@ -21,6 +21,14 @@ public class CpsDefaultGroovyMethods {
      * Interception is successful. The trick is to pre-translate this method into CPS.
      */
     public static <T> T each(T self, Closure closure) {
+        return _each(self,closure);
+    }
+
+    public static <T> Iterator<T> each(List<T> list, Closure closure) {
+        return _each(list,closure);
+    }
+
+    private static <T> T _each(T self, Closure closure) {
         if (!Caller.isAsynchronous(self,"each",closure)
          && !Caller.isAsynchronous(CpsDefaultGroovyMethods.class,"each",self,closure))
             return DefaultGroovyMethods.each(self,closure);
@@ -42,10 +50,6 @@ public class CpsDefaultGroovyMethods {
         ));
 
         throw new CpsCallableInvocation(f,null,self,closure);
-    }
-
-    public static <T> Iterator<T> each(List<T> iter, Closure closure) {
-        return each((Object)iter,closure);
     }
 
     public static <T> Iterator<T> each(Iterator<T> iter, Closure closure) {

--- a/src/main/groovy/com/cloudbees/groovy/cps/CpsDefaultGroovyMethods.groovy
+++ b/src/main/groovy/com/cloudbees/groovy/cps/CpsDefaultGroovyMethods.groovy
@@ -24,7 +24,7 @@ public class CpsDefaultGroovyMethods {
         return _each(self,closure);
     }
 
-    public static <T> Iterator<T> each(List<T> list, Closure closure) {
+    public static <T> List<T> each(List<T> list, Closure closure) {
         return _each(list,closure);
     }
 

--- a/src/main/java/com/cloudbees/groovy/cps/impl/ContinuationGroup.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/ContinuationGroup.java
@@ -14,6 +14,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.cloudbees.groovy.cps.impl.SourceLocation.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Base class for defining a series of {@link Continuation} methods that share the same set of contextual values.
@@ -25,6 +27,9 @@ import static com.cloudbees.groovy.cps.impl.SourceLocation.*;
  * @author Kohsuke Kawaguchi
  */
 abstract class ContinuationGroup implements Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(ContinuationGroup.class.getName());
+
     public Next then(Block exp, Env e, ContinuationPtr ptr) {
         return new Next(exp,e,ptr.bind(this));
     }
@@ -83,7 +88,11 @@ abstract class ContinuationGroup implements Serializable {
     }
 
     static {
-        DGMPatcher.init();
+        try {
+            DGMPatcher.init();
+        } catch (Throwable t) {
+            LOGGER.log(Level.WARNING, "cannot install JENKINS-26481 fix", t);
+        }
     }
 
     /**

--- a/src/main/java/com/cloudbees/groovy/cps/impl/DGMPatcher.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/DGMPatcher.java
@@ -20,6 +20,7 @@ import org.codehaus.groovy.runtime.metaclass.NewInstanceMetaMethod;
 import org.codehaus.groovy.util.AbstractConcurrentMapBase;
 import org.codehaus.groovy.util.AbstractConcurrentMapBase.Segment;
 import org.codehaus.groovy.util.FastArray;
+import org.codehaus.groovy.util.ManagedConcurrentLinkedQueue;
 import org.codehaus.groovy.util.ManagedLinkedList;
 
 import java.lang.management.LockInfo;
@@ -252,9 +253,18 @@ class DGMPatcher {
                     Object item = itr.next();
                     if (patch(item) != item) {
                         LOGGER.log(WARNING, "Can't replace members of ManagedLinkedList", item);
-                    // TODO would be possible, if necessary, by calling ManagedLinkedList.Item.remove on *all* elements, then using ManagedLinkedList.add to recreate the entire list
+                        // TODO would be possible, if necessary, by calling ManagedLinkedList.Item.remove on *all* elements, then using ManagedLinkedList.add to recreate the entire list
                     }
                 }
+            } else if (o instanceof ManagedConcurrentLinkedQueue) {
+                for (Iterator itr = ((ManagedConcurrentLinkedQueue) o).iterator(); itr.hasNext(); ) {
+                    Object item = itr.next();
+                    if (patch(item) != item) {
+                        LOGGER.log(WARNING, "Can't replace members of ManagedConcurrentLinkedQueue", item);
+                        // TODO would be possible, if necessary, by calling ManagedConcurrentLinkedQueue.Element.remove on *all* elements, then using ManagedLinkedList.add to recreate the entire list
+                    }
+                }
+
             } else if (o instanceof Segment) {
                 try {
                     Segment s = (Segment) o;

--- a/src/main/java/com/cloudbees/groovy/cps/impl/DGMPatcher.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/DGMPatcher.java
@@ -187,7 +187,7 @@ class DGMPatcher {
      * <p>
      * Key data structure we visit is {@link MetaClassImpl},
      */
-    private Object patch(Object o) {
+    private <T> T patch(T o) {
         if (o == null) {
             return null;
         }
@@ -244,7 +244,7 @@ class DGMPatcher {
             MetaMethod replace = overrides.get(new Key(gm));
             if (replace!=null) {
                 // we found a GeneratedMetaMethod that points to DGM that needs to be replaced!
-                return replace;
+                return (T)replace;
             }
         } else
 // other collection structure that needs to be recursively visited

--- a/src/main/java/com/cloudbees/groovy/cps/impl/DGMPatcher.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/DGMPatcher.java
@@ -305,18 +305,16 @@ class DGMPatcher {
                 if (replace != null) {
                     // we found a GeneratedMetaMethod that points to DGM that needs to be replaced!
                     PATCH_COUNT++;
-                    System.out.println("Patched #" + PATCH_COUNT+" "+replace);
-                    if (PATCH_COUNT == 10) {
-                        threadDump();
-                    }
-                    printTrail();
+//                    if (PATCH_COUNT == 10) {
+//                        threadDump();
+//                    }
+                    printTrail("Patched #" + PATCH_COUNT+" "+replace);
                     return (T) replace;
                 }
             } else if (o instanceof MetaMethod) {
                 // near hits
                 if (overrides.containsKey(new Key((MetaMethod)o))) {
-                    System.out.println("Near miss");
-                    printTrail();
+                    printTrail("Near miss");
                 }
             } else
             // other collection structure that needs to be recursively visited
@@ -357,7 +355,13 @@ class DGMPatcher {
         }
     }
 
-    private void printTrail() {
+    /**
+     * Optionally report the trail of patching for diagnostics.
+     */
+    private void printTrail(String header) {
+        if (!REPORT_TRAIL)      return;
+
+        System.out.println(header);
         for (Object t : trail) {
             if (t instanceof Collection)
                 t = t.getClass()+"[size="+((Collection)t).size()+"]";
@@ -436,6 +440,8 @@ class DGMPatcher {
     public static void init() {}
 
     private static int PATCH_COUNT = 0;
+
+    private static boolean REPORT_TRAIL = Boolean.getBoolean(DGMPatcher.class.getName()+".reportTrail");
 
     /**
      * Debug assistance: dump all the threads and report that to stdout

--- a/src/main/java/com/cloudbees/groovy/cps/impl/DGMPatcher.java
+++ b/src/main/java/com/cloudbees/groovy/cps/impl/DGMPatcher.java
@@ -42,6 +42,9 @@ import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static com.cloudbees.groovy.cps.impl.CollectionLiteralBlock.item;
+import static java.util.logging.Level.WARNING;
+
 /**
  * Patches Groovy's method dispatch table so that they point to {@link CpsDefaultGroovyMethods} instead of
  * {@link DefaultGroovyMethods}.
@@ -248,7 +251,7 @@ class DGMPatcher {
                 for (Iterator itr = ((ManagedLinkedList) o).iterator(); itr.hasNext(); ) {
                     Object item = itr.next();
                     if (patch(item) != item) {
-                        LOGGER.log(Level.WARNING, "Can't replace members of ManagedLinkedList", item);
+                        LOGGER.log(WARNING, "Can't replace members of ManagedLinkedList", item);
                     }
                 }
             } else if (o instanceof Segment) {
@@ -341,10 +344,15 @@ class DGMPatcher {
             } else if (o instanceof Set) {
                 Set s = (Set) o;
                 for (Object x : s.toArray()) {
+                    int h = x.hashCode();
                     Object y = patch(x);
                     if (x != y) {
                         s.remove(x);
                         s.add(y);
+                    } else {
+                        if (x.hashCode()!=h) {
+                            LOGGER.log(WARNING, "Hash code has changed", x);
+                        }
                     }
                 }
             }

--- a/src/test/groovy/com/cloudbees/groovy/cps/AaaMakeGroovyBusy.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/AaaMakeGroovyBusy.groovy
@@ -6,7 +6,7 @@ import org.junit.Test
  * Do something with Groovy to populate its system.
  *
  * Used to reproduce a failure in JENKINS-26481.
- * 
+ *
  * @author Kohsuke Kawaguchi
  */
 class AaaMakeGroovyBusy {

--- a/src/test/groovy/com/cloudbees/groovy/cps/AaaMakeGroovyBusy.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/AaaMakeGroovyBusy.groovy
@@ -1,0 +1,20 @@
+package com.cloudbees.groovy.cps
+
+import org.junit.Test
+
+/**
+ * Do something with Groovy to populate its system.
+ *
+ * Used to reproduce a failure in JENKINS-26481.
+ * 
+ * @author Kohsuke Kawaguchi
+ */
+class AaaMakeGroovyBusy {
+    @Test
+    public void warmUp() {
+        def sh = new GroovyShell()
+        sh.evaluate("""
+            [1,2,3,4].each { println it }
+        """)
+    }
+}

--- a/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -439,10 +439,10 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
     @Test
     void each() {
         assert evalCPS("""
-    def x = 0;
+    def x = 100;
     (0..10).each { y -> x+=y; }
     return x;
-""") == 55;
+""") == 155;
     }
 
     /**
@@ -618,9 +618,9 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
     @Test
     void eachArray() {
         assert evalCPS("""
-            def x = 0;
+            def x = 10;
             [1, 2, 3].each { y -> x+=y; }
             return x;
-        """) == 6;
+        """) == 16;
     }
 }


### PR DESCRIPTION
[JENKINS-34064](https://issues.jenkins-ci.org/browse/JENKINS-34064)

Subsumes https://github.com/cloudbees/groovy-cps/pull/24

I did a local build of core with Groovy 2.4.11, modified `workflow-cps` to roll back https://github.com/jenkinsci/workflow-cps-plugin/commit/efeee2b5a86ca2a5f03efd48fc2c1e596c57e2a2, and ran the `workflow-cps` tests against that tweaked core and this snapshot...and everything passed. 

I know `DGMPatcher` is not the ideal way to do this, but given that `CategorySupport` isn't viable due to it affecting the whole thread, I'd say this is worth doing as is. I'd really like to get this in so that I can work on adding more patched methods for things like `.collect`, `.collectEntries`, `.find`, etc...

cc @reviewbybees 