### PR TITLE
Use a trusted Builder for translation, except for Closure.call.

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/Builder.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/Builder.java
@@ -41,6 +41,7 @@ import com.cloudbees.groovy.cps.impl.WhileBlock;
 import com.cloudbees.groovy.cps.impl.YieldBlock;
 import com.cloudbees.groovy.cps.sandbox.CallSiteTag;
 import com.cloudbees.groovy.cps.sandbox.Invoker;
+import com.cloudbees.groovy.cps.sandbox.Trusted;
 import groovy.lang.Closure;
 import org.codehaus.groovy.runtime.GStringImpl;
 import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;

--- a/lib/src/main/java/com/cloudbees/groovy/cps/Builder.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/Builder.java
@@ -41,7 +41,6 @@ import com.cloudbees.groovy.cps.impl.WhileBlock;
 import com.cloudbees.groovy.cps.impl.YieldBlock;
 import com.cloudbees.groovy.cps.sandbox.CallSiteTag;
 import com.cloudbees.groovy.cps.sandbox.Invoker;
-import com.cloudbees.groovy.cps.sandbox.Trusted;
 import groovy.lang.Closure;
 import org.codehaus.groovy.runtime.GStringImpl;
 import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;


### PR DESCRIPTION
Eliminates the need to whitelist, well, a lot of things - i.e.,
anything called by a public method in CpsDefaultGroovyMethods. Still
retains the need to whitelist any of those public methods, and still
keeps the Closure.call contents covered by SandboxInvoker when
appropriate.

Tests are downstream in https://github.com/jenkinsci/workflow-cps-plugin/pull/139

@jglick - I can't actually deploy a SNAPSHOT, so if you could do so, I'd appreciate it. =)

cc @reviewbybees 