### PR TITLE
[FIXED JENKINS-38268] Proper lexical scoping for closure variables.

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
@@ -3,7 +3,6 @@ package com.cloudbees.groovy.cps.impl;
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,24 +27,23 @@ class ClosureCallEnv extends CallEnv {
         this.captured = captured;
     }
 
-    public void declareVariable(@Nonnull Class type, @Nonnull String name) {
+    public void declareVariable(Class type, String name) {
         locals.put(name,null);
         getTypes().put(name, type);
     }
 
-    public Object getLocalVariable(@Nonnull String name) {
+    public Object getLocalVariable(String name) {
         if (locals.containsKey(name))
             return locals.get(name);
         else
             return captured.getLocalVariable(name);
     }
 
-    public void setLocalVariable(@Nonnull String name, Object value) {
-        if (locals.containsKey(name) || captured.getLocalVariableType(name) == null) {
+    public void setLocalVariable(String name, Object value) {
+        if (locals.containsKey(name))
             locals.put(name, value);
-        } else {
+        else
             captured.setLocalVariable(name, value);
-        }
     }
 
     public Class getLocalVariableType(String name) {

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
@@ -41,10 +41,10 @@ class ClosureCallEnv extends CallEnv {
     }
 
     public void setLocalVariable(@Nonnull String name, Object value) {
-        if (!locals.containsKey(name) && captured.getLocalVariableType(name) != null) {
-            captured.setLocalVariable(name, value);
-        } else {
+        if (locals.containsKey(name) || captured.getLocalVariableType(name) == null) {
             locals.put(name, value);
+        } else {
+            captured.setLocalVariable(name, value);
         }
     }
 

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
@@ -3,6 +3,7 @@ package com.cloudbees.groovy.cps.impl;
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 
+import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,23 +28,24 @@ class ClosureCallEnv extends CallEnv {
         this.captured = captured;
     }
 
-    public void declareVariable(Class type, String name) {
+    public void declareVariable(@Nonnull Class type, @Nonnull String name) {
         locals.put(name,null);
         getTypes().put(name, type);
     }
 
-    public Object getLocalVariable(String name) {
+    public Object getLocalVariable(@Nonnull String name) {
         if (locals.containsKey(name))
             return locals.get(name);
         else
             return captured.getLocalVariable(name);
     }
 
-    public void setLocalVariable(String name, Object value) {
-        if (locals.containsKey(name))
-            locals.put(name, value);
-        else
+    public void setLocalVariable(@Nonnull String name, Object value) {
+        if (!locals.containsKey(name) && captured.getLocalVariableType(name) != null) {
             captured.setLocalVariable(name, value);
+        } else {
+            locals.put(name, value);
+        }
     }
 
     public Class getLocalVariableType(String name) {

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallable.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallable.java
@@ -45,6 +45,9 @@ public abstract class CpsCallable implements Serializable {
     protected final void assignArguments(List<?> args, Env e) {
         // TODO: var args
         for (int i=0; i< Math.min(args.size(),parameters.size()); i++) {
+            Class argClass = args.get(i) != null ? args.get(i).getClass() : Object.class;
+
+            e.declareVariable(argClass, parameters.get(i));
             e.setLocalVariable(parameters.get(i), args.get(i));
         }
     }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallable.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallable.java
@@ -45,9 +45,7 @@ public abstract class CpsCallable implements Serializable {
     protected final void assignArguments(List<?> args, Env e) {
         // TODO: var args
         for (int i=0; i< Math.min(args.size(),parameters.size()); i++) {
-            Class argClass = args.get(i) != null ? args.get(i).getClass() : Object.class;
-
-            e.declareVariable(argClass, parameters.get(i));
+            e.declareVariable(Object.class, parameters.get(i));
             e.setLocalVariable(parameters.get(i), args.get(i));
         }
     }

--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -777,4 +777,18 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
         ''') == 'FOO';
     }
 
+    @Issue("JENKINS-38268")
+    @Test
+    void lexicalScope() {
+        assert evalCPS('''
+def a = [id: 'a', count: 0]
+def b = [id: 'b', count: 0]
+
+def toRun = [a, b].collect { thing -> return { thing.count = thing.count + 1 } }
+
+toRun.each { arg -> arg() }
+
+return [a.count, b.count]
+''') == [1, 1]
+    }
 }


### PR DESCRIPTION
[JENKINS-38268](https://issues.jenkins-ci.org/browse/JENKINS-38268)

Previously, any variables that hadn't been explicitly declared (via
`ClosureCallEnv.declareVariable`) in a `Closure` would end up getting
set in the captured `Env`. Which means we'd end up setting things
globally when we really didn't mean to. This changes that to only set
a variable in the captured `Env` if there's no `locals` variable
defined by that name *and* the captured `Env` has a non-null return
for `getVariableType(name)` - i.e., the variable name has already been
declared in the captured `Env`.

Further tests in a `parallel` will be needed in `workflow-cps`.

cc @reviewbybees 