### PR TITLE
Use trusted builder for translation

### DIFF
--- a/dgm-builder/src/main/java/com/cloudbees/groovy/cps/tool/Translator.java
+++ b/dgm-builder/src/main/java/com/cloudbees/groovy/cps/tool/Translator.java
@@ -294,7 +294,8 @@ public class Translator {
         }
         delegatingParams.forEach(p -> delegateCall.arg(p));
 
-        JVar $b = m.body().decl($Builder, "b", JExpr._new($Builder).arg(JExpr.invoke("loc").arg(methodName)));
+        JVar $b = m.body().decl($Builder, "b", JExpr._new($Builder).arg(JExpr.invoke("loc").arg(methodName)).
+            invoke("contextualize").arg(codeModel.ref("com.cloudbees.groovy.cps.sandbox.Trusted").staticRef("INSTANCE")));
         JInvocation f = JExpr._new($CpsFunction);
 
         // parameter names


### PR DESCRIPTION
#60 stripped down to its essentials.

How I got here: I was worried that #60 would open a security vulnerability, specifically calls from `CpsDefaultGroovyMethods` (or its delegates) to user-defined methods that did not happen to be some `Closure.call` overload. So I hit on `Iterable.iterator`, which is also called on user-controlled arguments but for which we do not do the check. There was a snag that `IteratorHack` actually ignores _any_ override of this method, but even with that suppressed, the test did not fail the way I expected:

```diff
diff --git a/src/main/java/org/jenkinsci/plugins/workflow/cps/persistence/IteratorHack.java b/src/main/java/org/jenkinsci/plugins/workflow/cps/persistence/IteratorHack.java
index 06f7dbe1..1e119c30 100644
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/persistence/IteratorHack.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/persistence/IteratorHack.java
@@ -87,7 +87,7 @@ public class IteratorHack {
     }
 
     /** Serializable replacement for {@link List#iterator}. */
-    public static <E> Iterator<E> iterator(List<E> list) {
+    public static <E> Iterator<E> iteratorXXX(List<E> list) {
         // TODO !Caller.isAsynchronous(list, "iterator") && !Caller.isAsynchronous(IteratorHack.class, "iterator", list) when used from a Java 5-style for-loop, so not sure how to sidestep this when running in @NonCPS
         return new Itr<>(list);
     }
diff --git a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
index 90b6a1e9..4d6cf7af 100644
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -30,10 +30,14 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import static org.junit.Assert.*;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
 
 public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
 
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+
     /**
      * I should be able to have DSL call into async step and then bring it to the completion.
      */
@@ -79,4 +83,25 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
         jenkins.assertBuildStatus(Result.FAILURE, jenkins.waitForCompletion(r));
         jenkins.assertLogContains("org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance", r);
     }
+
+    @Test
+    public void sandboxInvokerUsedForReal() throws Exception {
+        WorkflowJob job = jenkins.jenkins.createProject(WorkflowJob.class, "p");
+        job.setDefinition(new CpsFlowDefinition("class L extends ArrayList {\n" +
+                "  public Iterator iterator() {\n" +
+                "    Jenkins.instance.systemMessage = 'bwahaha'\n" +
+                "    super.iterator()\n" +
+                "  }\n" +
+                "}\n" +
+                "def l = new L()\n" +
+                "l.add(1)\n" +
+                "l.collectEntries { e ->\n" +
+                "  [(e): e]\n" +
+                "}\n", true));
+
+        WorkflowRun r = job.scheduleBuild2(0).get();
+        assertEquals(null, jenkins.jenkins.getSystemMessage());
+        jenkins.assertBuildStatus(Result.FAILURE, r);
+        jenkins.assertLogContains("org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance", r);
+    }
 }
```

The sandbox check is still applied:

```
[p #1] org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance
[p #1] 	at org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist.rejectStaticMethod(StaticWhitelist.java:192)
[p #1] 	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor$12.reject(SandboxInterceptor.java:330)
[p #1] 	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onGetProperty(SandboxInterceptor.java:363)
[p #1] 	at org.kohsuke.groovy.sandbox.impl.Checker$4.call(Checker.java:241)
[p #1] 	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:238)
[p #1] 	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.getProperty(SandboxInvoker.java:28)
[p #1] 	at com.cloudbees.groovy.cps.impl.PropertyAccessBlock.rawGet(PropertyAccessBlock.java:20)
[p #1] 	at L.iterator(WorkflowScript:3)
[p #1] 	at com.cloudbees.groovy.cps.CpsDefaultGroovyMethods.collectEntries(CpsDefaultGroovyMethods:3564)
[p #1] 	at WorkflowScript.run(WorkflowScript:9)
[p #1] 	at …
```

Seems that the sandbox invoker is somehow stuck to the defining closure—or whatever it is—and you do not need to use a different tag when _calling_ that method. It just works.

So proposing this as an alternative, though I would like to get review by @kohsuke before this gets released.

An example generated method for reference:

```java
private static<T extends Object >Iterator<T> $each__java_util_Iterator__groovy_lang_Closure(Iterator<T> self, Closure closure) {
    Builder b = new Builder(loc("each")).contextualize(com.cloudbees.groovy.cps.sandbox.Trusted.INSTANCE);
    CpsFunction f = new CpsFunction(Arrays.asList("self", "closure"), b.block(b.while_(null, b.functionCall(2028, b.localVariable("self"), "hasNext"), b.block(b.declareVariable(2029, Object.class, "arg", b.functionCall(2029, b.localVariable("self"), "next")), b.functionCall(2030, b.localVariable("closure"), "call", b.localVariable("arg")))), b.return_(b.localVariable("self"))));
    throw new CpsCallableInvocation(f, null, self, closure);
}
```

@reviewbybees