### PR TITLE
Add groovy-sandbox.version POM property

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -11,6 +11,10 @@
 
   <name>Groovy CPS Execution</name>
 
+  <properties>
+    <groovy-sandbox.version>1.11</groovy-sandbox.version>
+  </properties>
+
   <build>
     <plugins>
         <plugin>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -125,13 +125,13 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>groovy-sandbox</artifactId>
-      <version>1.11</version>
+      <version>${groovy-sandbox.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>groovy-sandbox</artifactId>
-      <version>1.11</version>
+      <version>${groovy-sandbox.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <groovy.version>2.4.7</groovy.version>
+        <groovy-sandbox.version>1.11</groovy-sandbox.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <groovy.version>2.4.7</groovy.version>
-        <groovy-sandbox.version>1.11</groovy-sandbox.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
I'm working on tooling to do testing of core + groovy-sandbox +
groovy-cps + workflow-cps + script-security + the rest of the main
Pipeline plugins against bleeding-edge versions of each other and
different versions of Groovy. To do this, it'd be a lot easier if the
dependencies between the various things I'm building/testing had their
versions controlled by properties.

cc @reviewbybees 