### PR TITLE
[JENKINS-45982] Calls to CPS-transformed super methods fail

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -105,7 +105,7 @@
   </build>
 
   <properties>
-      <groovy-sandbox.version>1.14</groovy-sandbox.version>
+      <groovy-sandbox.version>1.17-20180227.180728-1</groovy-sandbox.version> <!-- TODO: Switch to release -->
   </properties>
   <dependencies>
     <dependency>

--- a/lib/src/main/java/com/cloudbees/groovy/cps/sandbox/DefaultInvoker.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/sandbox/DefaultInvoker.java
@@ -1,6 +1,7 @@
 package com.cloudbees.groovy.cps.sandbox;
 
 import com.cloudbees.groovy.cps.impl.CallSiteBlock;
+import groovy.lang.GroovyRuntimeException;
 import groovy.lang.MetaClass;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.codehaus.groovy.runtime.MethodClosure;
@@ -26,8 +27,12 @@ public class DefaultInvoker implements Invoker {
     }
 
     public Object superCall(Class methodType, Object receiver, String method, Object[] args) throws Throwable {
-        MetaClass mc = InvokerHelper.getMetaClass(receiver.getClass());
-        return mc.invokeMethod(methodType, receiver, method, args, true, true);
+        try {
+            MetaClass mc = InvokerHelper.getMetaClass(receiver.getClass());
+            return mc.invokeMethod(methodType, receiver, method, args, true, true);
+        } catch (GroovyRuntimeException gre) {
+            throw ScriptBytecodeAdapter.unwrap(gre);
+        }
     }
 
     public Object getProperty(Object lhs, String name) throws Throwable {

--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -750,14 +750,10 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
     void transformedSuperClass() {
         assert evalCPS('''
             class Foo extends CpsTransformerTest.Base {
-                public String toString() {
-                    return "x"+super.toString();
-                }
                 public String other() {
                     return "base"
                 }
             }
-            new Foo().toString()
             class Bar extends Foo {
                 public String other() {
                     return "y"+super.other()

--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -731,6 +731,7 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
             return "base";
         }
     }
+
     @Test
     void superClass() {
         assert evalCPS('''
@@ -741,6 +742,29 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
             }
             new Foo().toString();
         ''')=="xbase"
+    }
+
+    @NotYetImplemented
+    @Issue("JENKINS-45982")
+    @Test
+    void transformedSuperClass() {
+        assert evalCPS('''
+            class Foo extends CpsTransformerTest.Base {
+                public String toString() {
+                    return "x"+super.toString();
+                }
+                public String other() {
+                    return "base"
+                }
+            }
+            new Foo().toString()
+            class Bar extends Foo {
+                public String other() {
+                    return "y"+super.other()
+                }
+            }
+            new Bar().other();
+        ''')=="ybase"
     }
 
     @Test

--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -744,7 +744,6 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
         ''')=="xbase"
     }
 
-    @NotYetImplemented
     @Issue("JENKINS-45982")
     @Test
     void transformedSuperClass() {

--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.groovy
@@ -2,6 +2,7 @@ package com.cloudbees.groovy.cps.sandbox
 
 import com.cloudbees.groovy.cps.*
 import com.cloudbees.groovy.cps.impl.FunctionCallEnv
+import groovy.transform.NotYetImplemented
 import org.codehaus.groovy.runtime.ProxyGeneratorAdapter
 import org.junit.Before
 import org.junit.Test
@@ -208,6 +209,27 @@ Bar.toString()
 Bar.super(Foo).toString()
 String.plus(String)
 ''')
+    }
+
+    @NotYetImplemented
+    @Issue("JENKINS-45982")
+    @Test
+    void transformedSuperClass() {
+        assert evalCpsSandbox('''
+            class Foo extends SandboxInvokerTest.Base {
+                public String other() {
+                    return "base"
+                }
+            }
+            class Bar extends Foo {
+                public String other() {
+                    return "y"+super.other()
+                }
+            }
+            new Bar().other();
+        ''')=="ybase"
+
+        // TODO: add assertIntercept once this can actually work and we know the call tree.
     }
 
     @Issue("SECURITY-551")

--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.groovy
@@ -211,7 +211,6 @@ String.plus(String)
 ''')
     }
 
-    @NotYetImplemented
     @Issue("JENKINS-45982")
     @Test
     void transformedSuperClass() {


### PR DESCRIPTION
[JENKINS-45982](https://issues.jenkins-ci.org/browse/JENKINS-45982)

Initially just a test reproducing the issue described in JENKINS-45982 - specifically, that calling a `super` method when the `super` class is also CPS-transformed fails, due to a `CpsCallableInvocation` ending up in the way. Will grow this as I make progress towards a fix.

- [x] Test reproducing the issue
- [x] A fix

cc @reviewbybees 