### PR TITLE
[JENKINS-45904] Implicit string conversion for CPS-transformed classes fails

### DIFF
--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -814,4 +814,20 @@ def b = new CpsTransformerTest.Base()
 return (b.&toString)() + (String.getClass().&getSimpleName)()
 ''') == "baseClass"
     }
+
+    @NotYetImplemented
+    @Issue("JENKINS-45904")
+    @Test
+    void toStringCoercion() {
+        assert evalCPS('''
+class X implements Serializable {
+  public String toString() {
+    return "some string"
+  }
+}
+
+def x = new X()
+return "${x}"
+''') == "some string"
+    }
 }

--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.groovy
@@ -2,6 +2,7 @@ package com.cloudbees.groovy.cps.sandbox
 
 import com.cloudbees.groovy.cps.*
 import com.cloudbees.groovy.cps.impl.FunctionCallEnv
+import groovy.transform.NotYetImplemented
 import org.codehaus.groovy.runtime.ProxyGeneratorAdapter
 import org.junit.Before
 import org.junit.Test
@@ -379,4 +380,21 @@ SandboxInvokerTest$Base:staticOneArg(String)
 ''')
     }
 
+    @NotYetImplemented
+    @Issue("JENKINS-45904")
+    @Test
+    void toStringCoercion() {
+        assert evalCpsSandbox('''
+class X implements Serializable {
+  public String toString() {
+    return "some string"
+  }
+}
+
+def x = new X()
+return "${x}"
+''') == "some string"
+
+        // TODO: Add assertIntercept once this functionality works and we know the call stack
+    }
 }


### PR DESCRIPTION
[JENKINS-45904](https://issues.jenkins-ci.org/browse/JENKINS-45904)

Initially just a test reproducing the issue, which is that if you give a CPS-transformed class a `toString` override, and then try to implicitly convert an instance of that class to a string, such as in `echo "This will fail to print ${x}"` where `x` is an instance of such a class, you don't even get an `echo` in the logs - a `CpsCallableInvocation` pops up and throws everything off. Will update as I make progress on a fix.

- [x] Test reproducing issue
- [ ] A fix.

cc @reviewbybees 