### PR TITLE
Do nothing in CpsCallableInvocation.fillInStackTrace

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
@@ -49,4 +49,10 @@ public class CpsCallableInvocation extends Error/*not really an error but we wan
             }
         };
     }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+
 }


### PR DESCRIPTION
Just wastes time computing a stack trace for a throwable we intend to catch without logging.

(One approach to [JENKINS-31314](https://issues.jenkins-ci.org/browse/JENKINS-31314) might use the stack trace, but even then I think not.)

@reviewbybees