### PR TITLE
Reduce memory of CPS code significantly by lazily initializing locals maps

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/Envs.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/Envs.java
@@ -16,14 +16,14 @@ public class Envs {
      * regular Java program.
      */
     public static Env empty() {
-        return new FunctionCallEnv(null,Continuation.HALT,null,null);
+        return new FunctionCallEnv(null,Continuation.HALT,null,null, 0);
     }
 
     /**
      * Works like {@link #empty()} except it allows a custom {@link Invoker}.
      */
     public static Env empty(Invoker inv) {
-        FunctionCallEnv e = new FunctionCallEnv(null, Continuation.HALT, null, null);
+        FunctionCallEnv e = new FunctionCallEnv(null, Continuation.HALT, null, null, 0);
         e.setInvoker(inv);
         return e;
     }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/BlockScopeEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/BlockScopeEnv.java
@@ -14,7 +14,10 @@ import java.util.Map;
  */
 // TODO: should be package local once all the impls move into this class
 public class BlockScopeEnv extends ProxyEnv {
+    /** To conserve memory, lazily declared using {@link Collections#EMPTY_MAP} until we declare variables, then converted to a (small) {@link HashMap} */
     private Map<String,Object> locals;
+
+    /** To conserve memory, lazily declared using {@link Collections#EMPTY_MAP} until we declare variables, then converted to a (small) {@link HashMap} */
     private Map<String, Class> types;
 
     public BlockScopeEnv(Env parent) {
@@ -24,8 +27,9 @@ public class BlockScopeEnv extends ProxyEnv {
     public BlockScopeEnv(Env parent, int localsSize) {
         super(parent);
         if (localsSize <= 0) {
-            locals = Collections.emptyMap();
-            types = Collections.emptyMap();
+            // Lazily declare using EMPTY_MAP to conserve memory until we actually declare some variables
+            locals = Collections.EMPTY_MAP;
+            types = Collections.EMPTY_MAP;
         } else {
             locals = Maps.newHashMapWithExpectedSize(localsSize);
             types = Maps.newHashMapWithExpectedSize(localsSize);
@@ -54,7 +58,7 @@ public class BlockScopeEnv extends ProxyEnv {
     /** Because might deserialize old version of class with null value for field */
     private Map<String, Class> getTypes() {
         if (types == null) {
-            this.types = Collections.emptyMap();
+            this.types = Collections.EMPTY_MAP;
         }
         return this.types;
     }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/BlockScopeEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/BlockScopeEnv.java
@@ -2,6 +2,7 @@ package com.cloudbees.groovy.cps.impl;
 
 import com.cloudbees.groovy.cps.Env;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -12,20 +13,34 @@ import java.util.Map;
  */
 // TODO: should be package local once all the impls move into this class
 public class BlockScopeEnv extends ProxyEnv {
-    private final Map<String,Object> locals = new HashMap<String, Object>();
-    private Map<String, Class> types = new HashMap<String, Class>();
+    private Map<String,Object> locals;
+    private Map<String, Class> types;
 
     public BlockScopeEnv(Env parent) {
-        this(parent, 1);
+        this(parent, 0);
     }
 
-    public BlockScopeEnv(Env parent, int size) {
+    public BlockScopeEnv(Env parent, int localsSize) {
         super(parent);
+        if (localsSize <= 0) {
+            locals = Collections.emptyMap();
+            types = Collections.emptyMap();
+        } else {
+            locals = new HashMap<String, Object>(localsSize);
+            types = new HashMap<String, Class>(localsSize);
+        }
     }
 
     public void declareVariable(Class type, String name) {
+        if (locals == Collections.EMPTY_MAP) {
+            this.locals = new HashMap<String, Object>(1);
+        }
         locals.put(name, null);
-        getTypes().put(name, type);
+
+        if (types == null || types == Collections.EMPTY_MAP) {
+            types = new HashMap<String, Class>(1);
+        }
+        types.put(name, type);
     }
 
     public Object getLocalVariable(String name) {
@@ -38,7 +53,7 @@ public class BlockScopeEnv extends ProxyEnv {
     /** Because might deserialize old version of class with null value for field */
     private Map<String, Class> getTypes() {
         if (types == null) {
-            this.types = new HashMap<String, Class>();
+            this.types = Collections.emptyMap();
         }
         return this.types;
     }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/BlockScopeEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/BlockScopeEnv.java
@@ -1,6 +1,7 @@
 package com.cloudbees.groovy.cps.impl;
 
 import com.cloudbees.groovy.cps.Env;
+import com.google.common.collect.Maps;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,19 +27,19 @@ public class BlockScopeEnv extends ProxyEnv {
             locals = Collections.emptyMap();
             types = Collections.emptyMap();
         } else {
-            locals = new HashMap<String, Object>(localsSize);
-            types = new HashMap<String, Class>(localsSize);
+            locals = Maps.newHashMapWithExpectedSize(localsSize);
+            types = Maps.newHashMapWithExpectedSize(localsSize);
         }
     }
 
     public void declareVariable(Class type, String name) {
         if (locals == Collections.EMPTY_MAP) {
-            this.locals = new HashMap<String, Object>(1);
+            this.locals = new HashMap<String, Object>(2);
         }
         locals.put(name, null);
 
         if (types == null || types == Collections.EMPTY_MAP) {
-            types = new HashMap<String, Class>(1);
+            types = new HashMap<String, Class>(2);
         }
         types.put(name, type);
     }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/BlockScopeEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/BlockScopeEnv.java
@@ -16,6 +16,10 @@ public class BlockScopeEnv extends ProxyEnv {
     private Map<String, Class> types = new HashMap<String, Class>();
 
     public BlockScopeEnv(Env parent) {
+        this(parent, 1);
+    }
+
+    public BlockScopeEnv(Env parent, int size) {
         super(parent);
     }
 

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
@@ -6,6 +6,7 @@ import com.cloudbees.groovy.cps.Next;
 import com.cloudbees.groovy.cps.sandbox.Invoker;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,7 +18,7 @@ import java.util.Map;
  */
 /*package*/ abstract class CallEnv implements Env {
     private final Continuation returnAddress;
-    private Map<String, Class> types = new HashMap<String, Class>();
+    private Map<String, Class> types;
 
     /**
      * Caller environment, used for throwing an exception.
@@ -39,11 +40,16 @@ import java.util.Map;
      *      The environment of the call site. Can be null but only if the caller is outside CPS execution.
      */
     public CallEnv(Env caller, Continuation returnAddress, SourceLocation loc) {
+        this(caller, returnAddress, loc, 1);
+    }
+
+    public CallEnv(Env caller, Continuation returnAddress, SourceLocation loc, int localsCount) {
         this.caller = caller;
         this.returnAddress = returnAddress;
         this.callSiteLoc = loc;
         this.invoker = caller==null ? Invoker.INSTANCE : caller.getInvoker();
         assert returnAddress!=null;
+        types = new HashMap<String,Class>(localsCount);
     }
 
     /** Because might deserialize old version of class with null value for field */

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
@@ -49,13 +49,25 @@ import java.util.Map;
         this.callSiteLoc = loc;
         this.invoker = caller==null ? Invoker.INSTANCE : caller.getInvoker();
         assert returnAddress!=null;
-        types = new HashMap<String,Class>(localsCount);
+        if (localsCount <= 0) {
+            types = Collections.EMPTY_MAP;
+        } else {
+            types = new HashMap<String,Class>(localsCount);
+        }
     }
 
     /** Because might deserialize old version of class with null value for field */
     protected Map<String, Class> getTypes() {
         if (types == null) {
-            this.types = new HashMap<String, Class>();
+            this.types = Collections.emptyMap();
+        }
+        return this.types;
+    }
+
+    /** Used when we are actually going to mutate the types info */
+    protected Map<String,Class> getTypesForMutation() {
+        if (types == null || types == Collections.EMPTY_MAP) {
+            this.types = new HashMap<String, Class>(1);
         }
         return this.types;
     }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
@@ -19,6 +19,8 @@ import java.util.Map;
  */
 /*package*/ abstract class CallEnv implements Env {
     private final Continuation returnAddress;
+
+    /** To conserve memory, lazily declared using {@link Collections#EMPTY_MAP} until we declare variables, then converted to a (small) {@link HashMap} */
     private Map<String, Class> types;
 
     /**
@@ -60,7 +62,7 @@ import java.util.Map;
     /** Because might deserialize old version of class with null value for field */
     protected Map<String, Class> getTypes() {
         if (types == null) {
-            this.types = Collections.emptyMap();
+            this.types = Collections.EMPTY_MAP;
         }
         return this.types;
     }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CallEnv.java
@@ -4,6 +4,7 @@ import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 import com.cloudbees.groovy.cps.Next;
 import com.cloudbees.groovy.cps.sandbox.Invoker;
+import com.google.common.collect.Maps;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -52,7 +53,7 @@ import java.util.Map;
         if (localsCount <= 0) {
             types = Collections.EMPTY_MAP;
         } else {
-            types = new HashMap<String,Class>(localsCount);
+            types = Maps.newHashMapWithExpectedSize(localsCount);
         }
     }
 
@@ -67,7 +68,7 @@ import java.util.Map;
     /** Used when we are actually going to mutate the types info */
     protected Map<String,Class> getTypesForMutation() {
         if (types == null || types == Collections.EMPTY_MAP) {
-            this.types = new HashMap<String, Class>(1);
+            this.types = new HashMap<String, Class>(2);
         }
         return this.types;
     }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
@@ -3,6 +3,7 @@ package com.cloudbees.groovy.cps.impl;
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -12,7 +13,7 @@ import java.util.Map;
  * @author Kohsuke Kawaguchi
  */
 class ClosureCallEnv extends CallEnv {
-    final Map<String,Object> locals;
+    Map<String,Object> locals;
 
     final CpsClosure closure;
 
@@ -22,19 +23,26 @@ class ClosureCallEnv extends CallEnv {
     final Env captured;
 
     public ClosureCallEnv(Env caller, Continuation returnAddress, SourceLocation loc, Env captured, CpsClosure closure) {
-        this(caller, returnAddress, loc, captured, closure, 1);
+        this(caller, returnAddress, loc, captured, closure, 0);
     }
 
     public ClosureCallEnv(Env caller, Continuation returnAddress, SourceLocation loc, Env captured, CpsClosure closure, int localsSize) {
         super(caller,returnAddress,loc, localsSize);
         this.closure = closure;
         this.captured = captured;
-        locals = new HashMap<String, Object>(localsSize);
+        if (localsSize <= 0) {
+            locals = Collections.emptyMap();
+        } else {
+            locals = new HashMap<String, Object>(localsSize);
+        }
     }
 
     public void declareVariable(Class type, String name) {
-        locals.put(name,null);
-        getTypes().put(name, type);
+        if (locals == Collections.EMPTY_MAP) {
+            locals = new HashMap<String, Object>(1);
+        }
+        locals.put(name, null);
+        getTypesForMutation().put(name, type);
     }
 
     public Object getLocalVariable(String name) {

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
@@ -2,6 +2,7 @@ package com.cloudbees.groovy.cps.impl;
 
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
+import com.google.common.collect.Maps;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,13 +34,13 @@ class ClosureCallEnv extends CallEnv {
         if (localsSize <= 0) {
             locals = Collections.emptyMap();
         } else {
-            locals = new HashMap<String, Object>(localsSize);
+            locals = Maps.newHashMapWithExpectedSize(localsSize);
         }
     }
 
     public void declareVariable(Class type, String name) {
         if (locals == Collections.EMPTY_MAP) {
-            locals = new HashMap<String, Object>(1);
+            locals = new HashMap<String, Object>(2);
         }
         locals.put(name, null);
         getTypesForMutation().put(name, type);

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
@@ -14,6 +14,7 @@ import java.util.Map;
  * @author Kohsuke Kawaguchi
  */
 class ClosureCallEnv extends CallEnv {
+    /** Lazily declared using {@link Collections#EMPTY_MAP} until we declare variables, then converted to a (small) {@link HashMap} *//** To conserve memory, lazily declared using {@link Collections#EMPTY_MAP} until we declare variables, then converted to a (small) {@link HashMap} */
     Map<String,Object> locals;
 
     final CpsClosure closure;
@@ -32,7 +33,7 @@ class ClosureCallEnv extends CallEnv {
         this.closure = closure;
         this.captured = captured;
         if (localsSize <= 0) {
-            locals = Collections.emptyMap();
+            locals = Collections.EMPTY_MAP;
         } else {
             locals = Maps.newHashMapWithExpectedSize(localsSize);
         }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/ClosureCallEnv.java
@@ -12,7 +12,7 @@ import java.util.Map;
  * @author Kohsuke Kawaguchi
  */
 class ClosureCallEnv extends CallEnv {
-    final Map<String,Object> locals = new HashMap<String, Object>();
+    final Map<String,Object> locals;
 
     final CpsClosure closure;
 
@@ -22,9 +22,14 @@ class ClosureCallEnv extends CallEnv {
     final Env captured;
 
     public ClosureCallEnv(Env caller, Continuation returnAddress, SourceLocation loc, Env captured, CpsClosure closure) {
-        super(caller,returnAddress,loc);
+        this(caller, returnAddress, loc, captured, closure, 1);
+    }
+
+    public ClosureCallEnv(Env caller, Continuation returnAddress, SourceLocation loc, Env captured, CpsClosure closure, int localsSize) {
+        super(caller,returnAddress,loc, localsSize);
         this.closure = closure;
         this.captured = captured;
+        locals = new HashMap<String, Object>(localsSize);
     }
 
     public void declareVariable(Class type, String name) {

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsClosureDef.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsClosureDef.java
@@ -28,7 +28,7 @@ class CpsClosureDef extends CpsCallable {
 
     @Override
     Next invoke(Env caller, SourceLocation loc, Object receiver, List<?> args, Continuation k) {
-        Env e = new ClosureCallEnv(caller, k, loc, capture, self);
+        Env e = new ClosureCallEnv(caller, k, loc, capture, self, args.size());
 
         assignArguments(args, e);
 

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsFunction.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsFunction.java
@@ -18,7 +18,7 @@ public class CpsFunction extends CpsCallable {
     }
 
     public Next invoke(Env caller, SourceLocation loc, Object receiver, List<?> args, Continuation k) {
-        Env e = new FunctionCallEnv(caller, k, loc, receiver);
+        Env e = new FunctionCallEnv(caller, k, loc, receiver, args.size());
         assignArguments(args,e);
         return new Next(body, e, k);
     }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/ForInLoopBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/ForInLoopBlock.java
@@ -42,7 +42,7 @@ public class ForInLoopBlock implements Block {
         Iterator itr;
 
         ContinuationImpl(Env _e, Continuation loopEnd) {
-            this.e = new LoopBlockScopeEnv(_e,label,loopEnd,increment.bind(this));
+            this.e = new LoopBlockScopeEnv(_e,label,loopEnd,increment.bind(this),1);
             this.e.declareVariable(type,variable);
             this.loopEnd = loopEnd;
         }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
@@ -19,13 +19,13 @@ public class FunctionCallEnv extends CallEnv {
      *      The environment of the call site. Can be null but only if the caller is outside CPS execution.
      */
     public FunctionCallEnv(Env caller, Continuation returnAddress, SourceLocation loc, Object _this) {
-        this(caller, returnAddress, loc, _this, 1);
+        this(caller, returnAddress, loc, _this, 0);
     }
 
     public FunctionCallEnv(Env caller, Continuation returnAddress, SourceLocation loc, Object _this, int localsCount) {
         super(caller,returnAddress,loc, localsCount);
         locals = new HashMap<String, Object>(localsCount+1);
-        locals.put("this",_this);
+        locals.put("this", _this);
     }
 
     public void declareVariable(Class type, String name) {

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
@@ -12,14 +12,19 @@ import java.util.Map;
 // TODO: should be package local once all the impls move into this class
 public class FunctionCallEnv extends CallEnv {
     // TODO: delegate?
-    final Map<String,Object> locals = new HashMap<String, Object>();
+    Map<String,Object> locals;
 
     /**
      * @param caller
      *      The environment of the call site. Can be null but only if the caller is outside CPS execution.
      */
     public FunctionCallEnv(Env caller, Continuation returnAddress, SourceLocation loc, Object _this) {
-        super(caller,returnAddress,loc);
+        this(caller, returnAddress, loc, _this, 1);
+    }
+
+    public FunctionCallEnv(Env caller, Continuation returnAddress, SourceLocation loc, Object _this, int localsCount) {
+        super(caller,returnAddress,loc, localsCount);
+        locals = new HashMap<String, Object>(localsCount+1);
         locals.put("this",_this);
     }
 
@@ -29,7 +34,11 @@ public class FunctionCallEnv extends CallEnv {
     }
 
     public Object getLocalVariable(String name) {
-        return locals.get(name);
+        if (name.equals("this")) {
+            return closureOwner();
+        } else {
+            return locals.get(name);
+        }
     }
 
     public void setLocalVariable(String name, Object value) {

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
@@ -34,11 +34,7 @@ public class FunctionCallEnv extends CallEnv {
     }
 
     public Object getLocalVariable(String name) {
-        if (name.equals("this")) {
-            return closureOwner();
-        } else {
-            return locals.get(name);
-        }
+        return locals.get(name);
     }
 
     public void setLocalVariable(String name, Object value) {

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
@@ -2,6 +2,7 @@ package com.cloudbees.groovy.cps.impl;
 
 import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
+import com.google.common.collect.Maps;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,7 +25,7 @@ public class FunctionCallEnv extends CallEnv {
 
     public FunctionCallEnv(Env caller, Continuation returnAddress, SourceLocation loc, Object _this, int localsCount) {
         super(caller,returnAddress,loc, localsCount);
-        locals = new HashMap<String, Object>( (localsCount <= 0) ? 1 : localsCount+1);
+        locals = (localsCount <= 0) ? new HashMap<String, Object>(2) : Maps.<String,Object>newHashMapWithExpectedSize(localsCount+1);
         locals.put("this", _this);
     }
 

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
@@ -24,7 +24,7 @@ public class FunctionCallEnv extends CallEnv {
 
     public FunctionCallEnv(Env caller, Continuation returnAddress, SourceLocation loc, Object _this, int localsCount) {
         super(caller,returnAddress,loc, localsCount);
-        locals = new HashMap<String, Object>(localsCount+1);
+        locals = new HashMap<String, Object>( (localsCount <= 0) ? 1 : localsCount+1);
         locals.put("this", _this);
     }
 

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallEnv.java
@@ -4,6 +4,7 @@ import com.cloudbees.groovy.cps.Continuation;
 import com.cloudbees.groovy.cps.Env;
 import com.google.common.collect.Maps;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -12,7 +13,7 @@ import java.util.Map;
  */
 // TODO: should be package local once all the impls move into this class
 public class FunctionCallEnv extends CallEnv {
-    // TODO: delegate?
+    /** To conserve memory, lazily declared using {@link Collections#EMPTY_MAP} until we declare variables, then converted to a (small) {@link HashMap} */
     Map<String,Object> locals;
 
     /**

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/LoopBlockScopeEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/LoopBlockScopeEnv.java
@@ -13,7 +13,11 @@ class LoopBlockScopeEnv extends BlockScopeEnv {
     private final Continuation break_, continue_;
 
     LoopBlockScopeEnv(Env parent, String label, Continuation break_, Continuation continue_) {
-        super(parent);
+        this (parent, label, break_, continue_, 0);
+    }
+
+    LoopBlockScopeEnv(Env parent, String label, Continuation break_, Continuation continue_, int localsCount) {
+        super(parent, localsCount);
         this.label = label;
         this.break_ = break_;
         this.continue_ = continue_;

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/TryBlockEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/TryBlockEnv.java
@@ -17,7 +17,7 @@ import java.util.Map.Entry;
  */
 // TODO: should be package local once all the impls move into this class
 public class TryBlockEnv extends ProxyEnv {
-    private final Map<Class,Continuation> handlers = new LinkedHashMap<Class, Continuation>();
+    private final Map<Class,Continuation> handlers = new LinkedHashMap<Class, Continuation>(1);
     @Nullable
     private final Block finally_;
 

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/TryBlockEnv.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/TryBlockEnv.java
@@ -17,7 +17,7 @@ import java.util.Map.Entry;
  */
 // TODO: should be package local once all the impls move into this class
 public class TryBlockEnv extends ProxyEnv {
-    private final Map<Class,Continuation> handlers = new LinkedHashMap<Class, Continuation>(1);
+    private final Map<Class,Continuation> handlers = new LinkedHashMap<Class, Continuation>(2);
     @Nullable
     private final Block finally_;
 

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/TryCatchBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/TryCatchBlock.java
@@ -30,7 +30,7 @@ public class TryCatchBlock implements Block {
         for (final CatchExpression c : catches) {
             f.addHandler(c.type, new Continuation() {
                 public Next receive(Object t) {
-                    BlockScopeEnv b = new BlockScopeEnv(e);
+                    BlockScopeEnv b = new BlockScopeEnv(e, 1);
                     b.declareVariable(c.type, c.name);
                     b.setLocalVariable(c.name, t);
 


### PR DESCRIPTION
Provides a solution for #73 by lazily initializing the Maps for scoped environments, and starting them out sized for quite small arrays of locals since often blocks will be empty or have few variables. 

Why does this matter?  See the linked issue for jmap histogram of a real user who has quite a bit of memory consumed by HashMaps from these classes (in fact they're the third largest memory consumer there, even before their contents!). 

This should also reduce GC costs of pipeline rather significantly because the number of objects we create will be quite a bit smaller.

Included in https://github.com/jenkinsci/workflow-cps-plugin/pull/176 to run tests using this. 