### PR TITLE
[FIXED JENKINS-47071] Replace BooleanClosureWrapper with serializable

### DIFF
--- a/dgm-builder/src/main/java/com/cloudbees/groovy/cps/tool/Translator.java
+++ b/dgm-builder/src/main/java/com/cloudbees/groovy/cps/tool/Translator.java
@@ -413,7 +413,7 @@ public class Translator {
             public JExpression visitVariable(VariableTree vt, Void __) {
                 return $b.invoke("declareVariable")
                         .arg(loc(vt))
-                        .arg(erasure(vt).dotclass())
+                        .arg(cpsTypeTranslation(erasure(vt)))
                         .arg(n(vt))
                         .arg(visit(vt.getInitializer()));
             }
@@ -490,7 +490,7 @@ public class Translator {
 
                 return $b.invoke("new_").tap(inv -> {
                     inv.arg(loc(nt));
-                    inv.arg(t(((JCTree) nt).type).dotclass());
+                    inv.arg(cpsTypeTranslation(t(((JCTree) nt).type)));
                     nt.getArguments().forEach( et -> inv.arg(visit(et)) );
                 });
             }
@@ -843,6 +843,20 @@ public class Translator {
         case VOID:      return codeModel.VOID;
         }
         throw new UnsupportedOperationException(src.toString());
+    }
+
+    /**
+     * Replaces non-serializable types with CPS-specific variants.
+     *
+     * @param original a {@link JType} to inspect
+     * @return The {@link JType#dotclass()} for either the original {@link JType} or for the CPS equivalent.
+     */
+    private JExpression cpsTypeTranslation(JType original) {
+        if (original.fullName().equals("org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper")) {
+            return codeModel.ref("com.cloudbees.groovy.cps.impl.CpsBooleanClosureWrapper").dotclass();
+        } else {
+            return original.dotclass();
+        }
     }
 
     /**

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsBooleanClosureWrapper.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsBooleanClosureWrapper.java
@@ -1,0 +1,43 @@
+package com.cloudbees.groovy.cps.impl;
+
+import groovy.lang.Closure;
+import org.codehaus.groovy.runtime.callsite.BooleanReturningMethodInvoker;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * A serializable equivalent of {@link org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper}, where the
+ * {@link BooleanReturningMethodInvoker} is instantiated when {@link #call(Object...)} is called to avoid serialization
+ * issues with that as well.
+ */
+public class CpsBooleanClosureWrapper implements Serializable {
+    private final Closure wrapped;
+    private final int numberOfArguments;
+
+    public CpsBooleanClosureWrapper(Closure wrapped) {
+        this.wrapped = wrapped;
+        numberOfArguments = wrapped.getMaximumNumberOfParameters();
+    }
+
+    /**
+     * normal closure call
+     */
+    public boolean call(Object... args) {
+        BooleanReturningMethodInvoker bmi = new BooleanReturningMethodInvoker("call");
+        return bmi.invoke(wrapped, args);
+    }
+
+    /**
+     * Bridge for a call based on a map entry. If the call is done on a {@link Closure}
+     * taking one argument, then we give in the {@link Map.Entry}, otherwise we will
+     * give in the key and value.
+     */
+    public <K,V> boolean callForMap(Map.Entry<K, V> entry) {
+        if (numberOfArguments==2) {
+            return call(entry.getKey(), entry.getValue());
+        } else {
+            return call(entry);
+        }
+    }
+}

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsBooleanClosureWrapper.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsBooleanClosureWrapper.java
@@ -1,6 +1,7 @@
 package com.cloudbees.groovy.cps.impl;
 
 import groovy.lang.Closure;
+import org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper;
 import org.codehaus.groovy.runtime.callsite.BooleanReturningMethodInvoker;
 
 import java.io.Serializable;
@@ -13,19 +14,16 @@ import java.util.Map;
  */
 public class CpsBooleanClosureWrapper implements Serializable {
     private final Closure wrapped;
-    private final int numberOfArguments;
 
     public CpsBooleanClosureWrapper(Closure wrapped) {
         this.wrapped = wrapped;
-        numberOfArguments = wrapped.getMaximumNumberOfParameters();
     }
 
     /**
      * normal closure call
      */
     public boolean call(Object... args) {
-        BooleanReturningMethodInvoker bmi = new BooleanReturningMethodInvoker("call");
-        return bmi.invoke(wrapped, args);
+        return new BooleanClosureWrapper(wrapped).call(args);
     }
 
     /**
@@ -34,10 +32,6 @@ public class CpsBooleanClosureWrapper implements Serializable {
      * give in the key and value.
      */
     public <K,V> boolean callForMap(Map.Entry<K, V> entry) {
-        if (numberOfArguments==2) {
-            return call(entry.getKey(), entry.getValue());
-        } else {
-            return call(entry);
-        }
+        return new BooleanClosureWrapper(wrapped).callForMap(entry);
     }
 }


### PR DESCRIPTION
[JENKINS-47071](https://issues.jenkins-ci.org/browse/JENKINS-47071)

BooleanClosureWrapper isn't serializable, so attempts to serialize it
(i.e., saveProgram) result in errors. This replaces
BooleanClosureWrapper with CpsBooleanClosureWrapper, which *is*
serializable.

No point in testing here, but actual test coming downstream.

cc @reviewbybees 