### PR TITLE
[JENKINS-47363] Work around maximum varargs for decl of maps/lists

### DIFF
--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -877,4 +877,30 @@ def (c, d) = ['fourth']
 return [a, b, c, d].join(' ')
 ''') == "first second fourth null"
     }
+
+    @Issue("JENKINS-47363")
+    @Test
+    void bigList() {
+        def l = 0..300
+        def s = l.join(",")
+        assert evalCPS("""
+def b = [
+${s}
+]
+return b.size()
+""") == 301
+    }
+
+    @Issue("JENKINS-47363")
+    @Test
+    void bigMap() {
+        def l = 0..300
+        def s = l.collect { "${it}:${it}" }.join(",\n")
+        assert evalCPS("""
+def b = [
+${s}
+]
+return b.size()
+""") == 301
+    }
 }


### PR DESCRIPTION
[JENKINS-43763](https://issues.jenkins-ci.org/browse/JENKINS-47363)

Still not 100% sure this is a good idea. It may be better to error out
with a meaningful error message if excessively large map or list
expressions are detected.

The underlying issue is that ArrayUtil.createArray gets called when
Groovy is trying to figure out the right method to call, and it only
takes up to 250 possible elements. So lists of more than 250 elements
(or maps of more than 125 entries, since that ends up being 250
elements to Builder.map) fail with a NoSuchMethodError. This works
around that by splitting the list/map up into small enough chunks that
can then be added together. Like I said, still not sure it's a good idea.

cc @reviewbybees 