### PR TITLE
[JENKINS-47363] Meaningful errors for oversized map/list expressions

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/CpsTransformer.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/CpsTransformer.java
@@ -901,15 +901,20 @@ public class CpsTransformer extends CompilationCustomizer implements GroovyCodeV
 
     @Override
     public void visitMapExpression(final MapExpression exp) {
-        makeNode("map", new Runnable() {
-            @Override
-            public void run() {
-                for (MapEntryExpression e : exp.getMapEntryExpressions()) {
-                    visit(e.getKeyExpression());
-                    visit(e.getValueExpression());
+        if (exp.getMapEntryExpressions().size() > 125) {
+            sourceUnit.addError(new SyntaxException("Map expressions can only contain up to 125 entries",
+                    exp.getLineNumber(), exp.getColumnNumber()));
+        } else {
+            makeNode("map", new Runnable() {
+                @Override
+                public void run() {
+                    for (MapEntryExpression e : exp.getMapEntryExpressions()) {
+                        visit(e.getKeyExpression());
+                        visit(e.getValueExpression());
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     @Override
@@ -919,12 +924,17 @@ public class CpsTransformer extends CompilationCustomizer implements GroovyCodeV
 
     @Override
     public void visitListExpression(final ListExpression exp) {
-        makeNode("list", new Runnable() {
-            @Override
-            public void run() {
-                visit(exp.getExpressions());
-            }
-        });
+        if (exp.getExpressions().size() > 250) {
+            sourceUnit.addError(new SyntaxException("List expressions can only contain up to 250 elements",
+                    exp.getLineNumber(), exp.getColumnNumber()));
+        } else {
+            makeNode("list", new Runnable() {
+                @Override
+                public void run() {
+                    visit(exp.getExpressions());
+                }
+            });
+        }
     }
 
     @Override

--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -882,11 +882,18 @@ return [a, b, c, d].join(' ')
     @Issue("JENKINS-47363")
     @Test
     void excessiveListElements() {
-        def l = 0..250
-        def s = l.join(",\n")
+        def l1 = 0..249
+        def s1 = l1.join(",\n")
+        assert evalCPS("""
+def b = [${s1}]
+return b.size()
+""") == 250
+
+        def l2 = 0..250
+        def s2 = l2.join(",\n")
         try {
             assert evalCPS("""
-def b = [${s}]
+def b = [${s2}]
 return b.size()
 """) == 251
         } catch (Exception e) {
@@ -898,15 +905,22 @@ return b.size()
     @Issue("JENKINS-47363")
     @Test
     void excessiveMapElements() {
-        def l = 0..250
-        def s = l.collect { "${it}:${it}" }.join(",\n")
+        def l1 = 0..124
+        def s1 = l1.collect { "${it}:${it}" }.join(",\n")
+        assert evalCPS("""
+def b = [${s1}]
+return b.size()
+""") == 125
+        def l2 = 0..125
+        def s2 = l2.collect { "${it}:${it}" }.join(",\n")
         try {
             assert evalCPS("""
-def b = [${s}]
+def b = [${s2}]
 return b.size()
-""") == 251
+""") == 126
         } catch (Exception e) {
             assert e instanceof MultipleCompilationErrorsException
             assert e.message.contains('Map expressions can only contain up to 125 entries')
         }
-    }}
+    }
+}


### PR DESCRIPTION
[JENKINS-47363](https://issues.jenkins-ci.org/browse/JENKINS-47363)

This is probably better than #78 - that works around the problem, but
in a fairly hackish way, while this instead accepts the limitation and
gives a meaningful error message when a list expression is >250
elements or a map expression is >125 entries.

cc @reviewbybees 