### PR TITLE
[JENKINS-26313] Add javadoc explaining why constructors can't be transformed

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/CpsTransformer.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/CpsTransformer.java
@@ -157,6 +157,11 @@ public class CpsTransformer extends CompilationCustomizer implements GroovyCodeV
         }
     }
 
+    /**
+     * Constructors can't be transformed - if we throw a {@link CpsCallableInvocation} from inside a constructor, there's
+     * no way to get back to the continuation. The object does not get created and so we're unable to proceed with it.
+     * The same thing applies for object initializers.
+     */
     protected void processConstructors(ClassNode classNode) {
         for (ConstructorNode constructor : new ArrayList<>(classNode.getDeclaredConstructors())) {
             visitNontransformedMethod(constructor);


### PR DESCRIPTION
[JENKINS-26313](https://issues.jenkins-ci.org/browse/JENKINS-26313)

Note for myself and others in the future so we know why JENKINS-26313 is a won't fix and why we don't transform constructors.

cc @reviewbybees 