### PR TITLE
[JENKINS-31484] Add ignored test for unfixed variant of JENKINS-31484

### DIFF
--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -3,6 +3,7 @@ package com.cloudbees.groovy.cps
 import com.cloudbees.groovy.cps.impl.CpsCallableInvocation
 import groovy.transform.NotYetImplemented
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import org.junit.Ignore
 import org.junit.Test
 import org.jvnet.hudson.test.Issue
 
@@ -603,6 +604,13 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
     void fieldViaGetter() {
         assert evalCPS('class C {private int x = 33; int getX() {2 * this.@x}}; new C().x') == 66
         assert evalCPS('class C {private int x = 33; int getX() {2 * x}}; new C().x') == 66
+    }
+
+    @Issue("JENKINS-31484")
+    @Ignore("Currently throws StackOverflowError")
+    @Test
+    void fieldViaGetterWithThis() {
+        assert evalCPS('class C {private int x = 33; int getX() {2 * this.x}}; new C().x') == 66
     }
 
     @Issue("JENKINS-31484")


### PR DESCRIPTION
See [JENKINS-31484](https://issues.jenkins-ci.org/browse/JENKINS-31484).

This PR adds an ignored test for another variant of that issue that works in regular Groovy but not in groovy-cps.
