### PR TITLE
[JENKINS-57085] Avoid complex StackTraceElement.fileName values

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/CpsTransformer.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/CpsTransformer.java
@@ -284,11 +284,13 @@ public class CpsTransformer extends CompilationCustomizer implements GroovyCodeV
      * @param m Method being transformed.
      */
     protected Expression makeBuilder(MethodNode m) {
+        String sourceName = sourceUnit.getName();
+        sourceName = sourceName.substring(Math.max(sourceName.lastIndexOf('\\'), sourceName.lastIndexOf('/')) + 1); // JENKINS-57085
         Expression b = new ConstructorCallExpression(BUIDER_TYPE, new TupleExpression(
                 new ConstructorCallExpression(METHOD_LOCATION_TYPE, new TupleExpression(
                         new ConstantExpression(m.getDeclaringClass().getName()),
                         new ConstantExpression(m.getName()),
-                        new ConstantExpression(sourceUnit.getName())
+                        new ConstantExpression(sourceName)
                 ))
         ));
         b = new MethodCallExpression(b, "withClosureType",

--- a/lib/src/main/java/com/cloudbees/groovy/cps/MethodLocation.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/MethodLocation.java
@@ -22,6 +22,7 @@ public final class MethodLocation implements Serializable {
     public MethodLocation(String declaringClass, String methodName, String fileName) {
         this.declaringClass = declaringClass;
         this.methodName = methodName;
+        assert !fileName.contains(":") : "possible JENKINS-57085 violation in " + fileName;
         this.fileName = fileName;
     }
 


### PR DESCRIPTION
[JENKINS-57085](https://issues.jenkins-ci.org/browse/JENKINS-57085), in part a workaround for https://github.com/x-stream/xstream/pull/145, but also an analogue of https://github.com/apache/groovy/commit/7662296e5c2679d350f48d6d6f104d15c6f3c00d.