### PR TITLE
[JENKINS-58501] add exceptions for metaprogramming to CPS mismatches

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
@@ -59,12 +59,11 @@ public class CpsCallableInvocation extends Error/*not really an error but we wan
      */
     void checkMismatch(Object expectedReceiver, List<String> expectedMethodNames) {
         String expectedMethodName = expectedMethodNames.get(0);
-        // metaclass invokeMethod
+        
         if (expectedReceiver instanceof MetaClass && expectedMethodName.equals("invokeMethod")) {
             return; 
         }
 
-        // handle method missing
         if(methodName.equals("methodMissing")){
             return; 
         }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
@@ -10,6 +10,7 @@ import java.util.List;
 import static java.util.Arrays.*;
 import java.util.Collections;
 import javax.annotation.CheckForNull;
+import groovy.lang.MetaClass; 
 
 /**
  * When an CPS-interpreted method is invoked, it immediately throws this error
@@ -57,10 +58,21 @@ public class CpsCallableInvocation extends Error/*not really an error but we wan
      * @see <a href="https://issues.jenkins-ci.org/browse/JENKINS-31314">JENKINS-31314</a>
      */
     void checkMismatch(Object expectedReceiver, List<String> expectedMethodNames) {
+        String expectedMethodName = expectedMethodNames.get(0);
+        // metaclass invokeMethod
+        if(MetaClass.class.isInstance(expectedReceiver) && expectedMethodName.equals("invokeMethod")){
+            return; 
+        }
+
+        // handle method missing
+        if(methodName.equals("methodMissing")){
+            return; 
+        }
+
         if (!expectedMethodNames.contains(methodName)) {
             MismatchHandler handler = handlers.get();
             if (handler != null) {
-                handler.handle(expectedReceiver, expectedMethodNames.get(0), receiver, methodName);
+                handler.handle(expectedReceiver, expectedMethodName, receiver, methodName);
             }
         }
     }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
@@ -60,7 +60,7 @@ public class CpsCallableInvocation extends Error/*not really an error but we wan
     void checkMismatch(Object expectedReceiver, List<String> expectedMethodNames) {
         String expectedMethodName = expectedMethodNames.get(0);
         // metaclass invokeMethod
-        if(MetaClass.class.isInstance(expectedReceiver) && expectedMethodName.equals("invokeMethod")){
+        if (expectedReceiver instanceof MetaClass && expectedMethodName.equals("invokeMethod")) {
             return; 
         }
 


### PR DESCRIPTION
Hey, thought i'd take a stab at implementing the fix for the pull requests against https://github.com/jenkinsci/workflow-cps-plugin/pull/305 and https://github.com/jenkinsci/workflow-cps-plugin/pull/306.

Just trying to lend a helping hand!  The unit tests added in the workflow-cps-plugin that are failing due to the false positives are passing with this change. 