### PR TITLE
JENKINS-58620 GroovyShell.evaluate should be skipped in the mismatch handler

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/ContinuationGroup.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/ContinuationGroup.java
@@ -75,6 +75,8 @@ abstract class ContinuationGroup implements Serializable {
                     // CpsScript.invokeMethod e.g. on a UserDefinedGlobalVariable cannot be predicted from here.
                     expectedMethodNames.add("call");
                     laxCall = !((Script) effectiveReceiver).getBinding().getVariables().containsKey(methodName); // lax unless like invokePropertyOrMissing
+                } else if (effectiveReceiver instanceof GroovyShell && methodName.equals("evaluate")) {
+                    expectedMethodNames.add("run");
                 } else if (effectiveReceiver instanceof CpsBooleanClosureWrapper && methodName.equals("callForMap")) {
                     expectedMethodNames.add("call");
                 } else if ((effectiveReceiver instanceof ListWithDefault || effectiveReceiver instanceof MapWithDefault) && methodName.equals("get")) {


### PR DESCRIPTION
Tests placed into jenkinsci/workflow-cps-plugin#315