### PR TITLE
[FIXED JENKINS-58407] Treat closure fields and map values properly

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
@@ -15,9 +15,7 @@ import javax.annotation.CheckForNull;
 import groovy.lang.Closure;
 import groovy.lang.GroovyObject;
 import groovy.lang.MetaClass;
-import groovy.lang.MetaProperty;
 import groovy.lang.MissingPropertyException;
-import org.codehaus.groovy.runtime.metaclass.MissingPropertyExceptionNoStack;
 
 /**
  * When an CPS-interpreted method is invoked, it immediately throws this error

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
@@ -16,6 +16,8 @@ import groovy.lang.Closure;
 import groovy.lang.GroovyObject;
 import groovy.lang.MetaClass;
 import groovy.lang.MetaProperty;
+import groovy.lang.MissingPropertyException;
+import org.codehaus.groovy.runtime.metaclass.MissingPropertyExceptionNoStack;
 
 /**
  * When an CPS-interpreted method is invoked, it immediately throws this error
@@ -70,9 +72,13 @@ public class CpsCallableInvocation extends Error/*not really an error but we wan
         }
 
         if (expectedReceiver instanceof GroovyObject) {
-            Object propVal = ((GroovyObject) expectedReceiver).getMetaClass().getProperty(expectedReceiver, expectedMethodName);
-            if (propVal instanceof Closure) {
-                return;
+            try {
+                Object propVal = ((GroovyObject) expectedReceiver).getMetaClass().getProperty(expectedReceiver, expectedMethodName);
+                if (propVal instanceof Closure) {
+                    return;
+                }
+            } catch (MissingPropertyException mpe) {
+                // Do nothing - this just means the property didn't exist.
             }
         }
         if (expectedReceiver instanceof Map && ((Map) expectedReceiver).containsKey(expectedMethodName)) {

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
@@ -9,8 +9,13 @@ import java.util.List;
 
 import static java.util.Arrays.*;
 import java.util.Collections;
+import java.util.Map;
 import javax.annotation.CheckForNull;
-import groovy.lang.MetaClass; 
+
+import groovy.lang.Closure;
+import groovy.lang.GroovyObject;
+import groovy.lang.MetaClass;
+import groovy.lang.MetaProperty;
 
 /**
  * When an CPS-interpreted method is invoked, it immediately throws this error
@@ -62,6 +67,19 @@ public class CpsCallableInvocation extends Error/*not really an error but we wan
         
         if (expectedReceiver instanceof MetaClass && expectedMethodName.equals("invokeMethod")) {
             return; 
+        }
+
+        if (expectedReceiver instanceof GroovyObject) {
+            Object propVal = ((GroovyObject) expectedReceiver).getMetaClass().getProperty(expectedReceiver, expectedMethodName);
+            if (propVal instanceof Closure) {
+                return;
+            }
+        }
+        if (expectedReceiver instanceof Map && ((Map) expectedReceiver).containsKey(expectedMethodName)) {
+            Object mapVal = ((Map) expectedReceiver).get(expectedMethodName);
+            if (mapVal instanceof Closure) {
+                return;
+            }
         }
 
         if(methodName.equals("methodMissing")){

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
@@ -69,20 +69,22 @@ public class CpsCallableInvocation extends Error/*not really an error but we wan
             return; 
         }
 
-        if (expectedReceiver instanceof GroovyObject) {
-            try {
-                Object propVal = ((GroovyObject) expectedReceiver).getMetaClass().getProperty(expectedReceiver, expectedMethodName);
-                if (propVal instanceof Closure) {
+        if ("call".equals(methodName) && !expectedMethodNames.contains(methodName)) {
+            if (expectedReceiver instanceof GroovyObject) {
+                try {
+                    Object propVal = ((GroovyObject) expectedReceiver).getMetaClass().getProperty(expectedReceiver, expectedMethodName);
+                    if (propVal instanceof Closure) {
+                        return;
+                    }
+                } catch (MissingPropertyException mpe) {
+                    // Do nothing - this just means the property didn't exist.
+                }
+            }
+            if (expectedReceiver instanceof Map && ((Map) expectedReceiver).containsKey(expectedMethodName)) {
+                Object mapVal = ((Map) expectedReceiver).get(expectedMethodName);
+                if (mapVal instanceof Closure) {
                     return;
                 }
-            } catch (MissingPropertyException mpe) {
-                // Do nothing - this just means the property didn't exist.
-            }
-        }
-        if (expectedReceiver instanceof Map && ((Map) expectedReceiver).containsKey(expectedMethodName)) {
-            Object mapVal = ((Map) expectedReceiver).get(expectedMethodName);
-            if (mapVal instanceof Closure) {
-                return;
             }
         }
 


### PR DESCRIPTION
[JENKINS-58407](https://issues.jenkins-ci.org/browse/JENKINS-58407)

Don't throw a mismatch for cases like `foo.someField()` where `foo` is
either an `Object` with a field `someField` that's a closure, or a
`Map` with a `Closure` value for the key `someField`.

https://github.com/jenkinsci/workflow-cps-plugin/pull/316