### PR TITLE
Suppress mismatch warnings for invocations of Continuable.suspend

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
@@ -60,6 +60,10 @@ public class CpsCallableInvocation extends Error/*not really an error but we wan
     void checkMismatch(Object expectedReceiver, List<String> expectedMethodNames) {
         String expectedMethodName = expectedMethodNames.get(0);
         
+        if (call == SuspendBlock.SUSPEND) {
+            return;
+        }
+
         if (expectedReceiver instanceof MetaClass && expectedMethodName.equals("invokeMethod")) {
             return; 
         }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/CpsCallableInvocation.java
@@ -60,7 +60,7 @@ public class CpsCallableInvocation extends Error/*not really an error but we wan
     void checkMismatch(Object expectedReceiver, List<String> expectedMethodNames) {
         String expectedMethodName = expectedMethodNames.get(0);
         
-        if (call == SuspendBlock.SUSPEND) {
+        if (call.body instanceof SuspendBlock) {
             return;
         }
 


### PR DESCRIPTION
`Continuable.suspend` explicitly changes control flow in a way that we can't track, so we shouldn't warn about it.

CC @alexanderrtaylor 