### PR TITLE
Avoid java.io.NotSerializableException: java.util.ArrayList$Itr

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/ForInLoopBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/ForInLoopBlock.java
@@ -39,7 +39,7 @@ public class ForInLoopBlock implements Block {
         final Continuation loopEnd;
         final Env e;
 
-        Iterator itr;
+        transient Iterator itr;
 
         ContinuationImpl(Env _e, Continuation loopEnd) {
             this.e = new LoopBlockScopeEnv(_e,label,loopEnd,increment.bind(this),1);


### PR DESCRIPTION
Avoid java.io.NotSerializableException: java.util.ArrayList$Itr:
	in field com.cloudbees.groovy.cps.impl.ForInLoopBlock$ContinuationImpl.itr
	in object com.cloudbees.groovy.cps.impl.ForInLoopBlock$ContinuationImpl@7f282ca0
	in field com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl.target
	in object com.cloudbees.groovy.cps.impl.ContinuationPtr$ContinuationImpl@57319f0f
	in field com.cloudbees.groovy.cps.impl.LoopBlockScopeEnv.continue_
        ...