### PR TITLE
JENKINS-33925 Sample realization of the cps invoker interceptor

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/sandbox/DefaultInvoker.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/sandbox/DefaultInvoker.java
@@ -14,8 +14,8 @@ import org.codehaus.groovy.runtime.callsite.CallSiteArray;
  *
  * @author Kohsuke Kawaguchi
  */
-public class DefaultInvoker implements Invoker {
-    public Object methodCall(Object receiver, String method, Object[] args) throws Throwable {
+public class DefaultInvoker extends InvokerInterceptor {
+    public Object doMethodCall(Object receiver, String method, Object[] args) throws Throwable {
         CallSite callSite = fakeCallSite(method);
         Object v = callSite.call(receiver,args);
         return v;

--- a/lib/src/main/java/com/cloudbees/groovy/cps/sandbox/InvokerInterceptor.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/sandbox/InvokerInterceptor.java
@@ -1,0 +1,16 @@
+package com.cloudbees.groovy.cps.sandbox;
+
+/**
+ * Allows to override one class to perform real-life tests of the CPS logic
+ *
+ * @author Sergei Parshev <sergei@parshev.net>
+ */
+public abstract class InvokerInterceptor implements Invoker {
+    public Object methodCall(Object receiver, String method, Object[] args) throws Throwable {
+        return doMethodCall(receiver, method, args);
+    }
+
+    abstract Object doMethodCall(Object receiver, String method, Object[] args) throws Throwable;
+
+    private static final long serialVersionUID = 1L;
+}

--- a/lib/src/main/java/com/cloudbees/groovy/cps/sandbox/SandboxInvoker.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/sandbox/SandboxInvoker.java
@@ -12,8 +12,8 @@ import org.kohsuke.groovy.sandbox.impl.SandboxedMethodClosure;
  *
  * @author Kohsuke Kawaguchi
  */
-public class SandboxInvoker implements Invoker {
-    public Object methodCall(Object receiver, String method, Object[] args) throws Throwable {
+public class SandboxInvoker extends InvokerInterceptor {
+    public Object doMethodCall(Object receiver, String method, Object[] args) throws Throwable {
         return Checker.checkedCall(receiver,false,false,method,args);
     }
 


### PR DESCRIPTION
fixes: #106 

### Realization:
JenkinsRule allows to run actual jenkins with actual plugins, but it's hard to intercept the calls. That could be done through CpsScript & CPSClosure (workflow-cps-plugin) or through Invoker (groovy-cps). Intercepting of CpsScript is hard (final method, too much logic...), but intercepting the Invoker is easier and allows better control of the execution, so the best candidate to intercept.

The main idea behind the changes is to provide a relatively easy way for custom interceptions. I think it’s the most secure way that requires a minimal number of changes and allows to prepare a custom logic for the ones who want to prepare flexible unit/integration tests of the CPS logic.
It changes the interface for the invokers which could be intercepted, but should not break not break the basic Invoker interface.
I thought about a number of interceptions to the existing code:
1. Create overrides of `com.cloudbees.groovy.cps.sandbox.DefaultInvoker` and `com.cloudbees.groovy.cps.sandbox.SandboxInvoker` - looks ok, but not for debugging - it’s hard to understand what the class is used - the original one or the overridden one.
2. Overriding of `com.cloudbees.groovy.cps.sandbox.Invoker` and `com.cloudbees.groovy.cps.impl.FunctionCallEnv` with creating extensions `MPLDefaultInvoker` & `MPLSandboxInvoker` - the traces looks better and showing where the issue and that the Invoker classes are overridden, but still requires too much original code from groovy-cps.
3. Generating override classes dynamically - looks complicated, but it is another way to implement the idea. Will require to get sources of groovy-cps, unpack them and apply patches to the required classes.
4. This one with modifying the groovy-cps code.

### Usage
With this changes - all the user need to do - is to add an override the original `InvokerInterceptor`:
* `test/java/com/cloudbees/groovy/cps/sandbox/InvokerInterceptor.java`:
    ```
    package com.cloudbees.groovy.cps.sandbox;
    import com.griddynamics.devops.mpl.testing.MPLInterceptor

    public abstract class InvokerInterceptor implements Invoker {
        public Object methodCall(Object receiver, String method, Object[] args) throws Throwable {
            return MPLInterceptor.instance.processMethodCall(this.&doMethodCall, this.class.getSimpleName(), receiver, method, args);
        }
        abstract Object doMethodCall(Object receiver, String method, Object[] args) throws Throwable;
        private static final long serialVersionUID = 1L;
    }
    ```

### Notice
Quite the same was [prepared for MPL](https://github.com/griddynamics/mpl/pull/49) (right now using the second solution)