### PR TITLE
[JENKINS-62064] Make assignment expressions evaluate to their RHS

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/AssignmentBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/AssignmentBlock.java
@@ -64,10 +64,10 @@ public class AssignmentBlock extends CallSiteBlockSupport {
         }
 
         /**
-         * Just straight assignment from RHS to LHS, then done
+         * Assign from RHS to LHS and pass RHS to the continuation.
          */
         public Next assignAndDone(Object rhs) {
-            return lhs.set(rhs,k);  // just straight assignment
+            return lhs.set(rhs, then(new ConstantBlock(rhs), e, k));
         }
 
         /**

--- a/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformer2Test.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformer2Test.java
@@ -74,4 +74,14 @@ public class CpsTransformer2Test extends AbstractGroovyCpsTest {
                 "m2('x', 'b', 'y')\n" +
                 "r"));
     }
+
+    @Test public void assignmentExprsEvalToRHS() throws Throwable {
+        assertEquals(Arrays.asList(1, 1, 1), evalCPS(
+                "def a = b = c = 1\n" +
+                "[a, b, c]\n"));
+        assertEquals(Arrays.asList(2, 3, 4), evalCPS(
+                "def a = b = c = 1\n" +
+                "c += b += a += 1\n" +
+                "[a, b, c]\n"));
+    }
 }


### PR DESCRIPTION
See [JENKINS-62064](https://issues.jenkins-ci.org/browse/JENKINS-62064).

Fixes a case where groovy-cps semantics did not match Groovy semantics.