### PR TITLE
[JENKINS-57253] Verify correct usage of break and continue statements during compilation

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/CpsTransformer.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/CpsTransformer.java
@@ -30,6 +30,7 @@ import org.codehaus.groovy.classgen.GeneratorContext;
 import org.codehaus.groovy.classgen.Verifier;
 import org.codehaus.groovy.control.CompilePhase;
 import org.codehaus.groovy.control.Janitor;
+import org.codehaus.groovy.control.LabelVerifier;
 import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.control.customizers.CompilationCustomizer;
 import org.codehaus.groovy.runtime.powerassert.SourceText;
@@ -123,6 +124,9 @@ public class CpsTransformer extends CompilationCustomizer implements GroovyCodeV
         }
         this.sourceUnit = source;
         this.classNode = classNode;
+
+        // Makes sure that break and continue statements are used correctly.
+        new LabelVerifier(source).visitClass(classNode);
 
         // Removes all initial expressions for methods and constructors and generates overloads for all variants.
         new InitialExpressionExpander().expandInitialExpressions(classNode);

--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/AbstractGroovyCpsTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/AbstractGroovyCpsTest.groovy
@@ -23,7 +23,7 @@ abstract class AbstractGroovyCpsTest extends Assert {
      */
     GroovyShell sh;
 
-    def binding = new Binding()
+    Binding binding = new Binding()
 
     @Before
     void setUp() {

--- a/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformer2Test.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformer2Test.java
@@ -18,7 +18,9 @@ package com.cloudbees.groovy.cps;
 
 import java.util.Arrays;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 
 public class CpsTransformer2Test extends AbstractGroovyCpsTest {
@@ -73,5 +75,17 @@ public class CpsTransformer2Test extends AbstractGroovyCpsTest {
                 "m2('x', 'b')\n" +
                 "m2('x', 'b', 'y')\n" +
                 "r"));
+    }
+
+    @Issue("JENKINS-57253")
+    @Test public void illegalBreakStatement() {
+        getBinding().setProperty("sentinel", 1);
+        try {
+            evalCPSonly("sentinel = 2; break;");
+            fail("Execution should fail");
+        } catch (Exception e) {
+            assertThat(e.toString(), containsString("the break statement is only allowed inside loops or switches"));
+        }
+        assertEquals("Script should fail during compilation", 1, getBinding().getProperty("sentinel"));
     }
 }


### PR DESCRIPTION
See [JENKINS-57253](https://issues.jenkins-ci.org/browse/JENKINS-57253) and https://github.com/jenkinsci/workflow-cps-plugin/pull/356 (CC @basil).

Makes improper use of `break` or `continue` statements fail during compilation with the same error messages as Groovy itself instead of at runtime with a CPS-specific error message.

`LabelVerifier` normally runs during `CompilePhase.CLASS_GENERATION`, but CPS transformation runs earlier during `CompilePhase.CANONICALIZATION` and obliterates the original control-flow statements that `LabelVerifier` would check, so the `LabelVerifier` that runs during `CompilePhase.CLASS_GENERATION` can only catch issues in groovy-cps itself. 

To be able to catch errors in the user's program, this PR makes `CPSTransformer` run `LabelVerifier` manually prior to performing the CPS transformation. Looking at `LabelVerifier`, I do not think there are problems with running it during an earlier compilation phase.