### PR TITLE
Bump Groovy from 2.4.7 to 2.4.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <groovy.version>2.4.7</groovy.version>
+        <groovy.version>2.4.21</groovy.version>
         <revision>1.33</revision>
         <changelist>-SNAPSHOT</changelist>
         <!-- TODO: Move these three properties to the parent POM or use org.jenkins-ci:jenkins as the parent POM here -->

--- a/pom.xml
+++ b/pom.xml
@@ -194,4 +194,10 @@
         </profile>
     </profiles>
 
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -194,10 +194,4 @@
         </profile>
     </profiles>
 
-  <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </repository>
-  </repositories>
 </project>


### PR DESCRIPTION
Not for review. Filing for testing purposes. Timestamped snapshots built locally (with passing tests!) available at:

https://repo.jenkins-ci.org/artifactory/snapshots/com/cloudbees/groovy-cps/1.33-SNAPSHOT/