### PR TITLE
Demonstrating GROOVY-9608 method interception

### DIFF
--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.groovy
@@ -553,9 +553,13 @@ HandleMetaClass.getAttribute(Class,B,String,Boolean)
               public x = 'B'
             }
             def b = new B()
-            def bSuperX = b.metaClass.getAttribute(A, b, 'x', true)
-            return bSuperX
-            ''') == "B"
+            try {
+                def bSuperX = b.metaClass.getAttribute(A, b, 'x', true)
+                return bSuperX
+            } catch (MissingFieldException e) {
+                return e.message
+                // TODO: Why can't these read public/protected field from super?
+            }''') == "No such field: x for class: A"
         assertIntercept(
 '''
 Script1.super(Script1).setBinding(Binding)
@@ -572,6 +576,7 @@ new B()
 new A()
 B.metaClass
 HandleMetaClass.getAttribute(Class,B,String,Boolean)
+MissingFieldException.message
 ''')
         assert evalCpsSandbox('''
             import org.codehaus.groovy.runtime.ScriptBytecodeAdapter
@@ -582,9 +587,13 @@ HandleMetaClass.getAttribute(Class,B,String,Boolean)
               public x = 'B'
             }
             def b = new B()
-            def bSuperX = ScriptBytecodeAdapter.getFieldOnSuper(A, b, 'x')
-            return bSuperX
-            ''') == "B"
+            try {
+                def bSuperX = ScriptBytecodeAdapter.getFieldOnSuper(A, b, 'x')
+                return bSuperX
+            } catch (MissingFieldException e) {
+                return e.message
+                // TODO: Why can't these read public/protected field from super?
+            }''') == "No such field: x for class: A"
         assertIntercept('''
 Script1.super(Script1).setBinding(Binding)
 new A()
@@ -600,10 +609,12 @@ new B()
 new A()
 B.metaClass
 HandleMetaClass.getAttribute(Class,B,String,Boolean)
+MissingFieldException.message
 Script4.super(Script4).setBinding(Binding)
 new B()
 new A()
 ScriptBytecodeAdapter:getFieldOnSuper(Class,B,String)
+MissingFieldException.message
 ''')
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <groovy.version>2.4.7</groovy.version>
+        <groovy.version>2.4.21</groovy.version>
         <revision>1.33</revision>
         <changelist>-SNAPSHOT</changelist>
         <!-- TODO: Move these three properties to the parent POM or use org.jenkins-ci:jenkins as the parent POM here -->

--- a/pom.xml
+++ b/pom.xml
@@ -194,4 +194,10 @@
         </profile>
     </profiles>
 
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
Demonstrating that apache/groovy@cf51a3f fixes [GROOVY-9608](https://issues.apache.org/jira/browse/GROOVY-9608) without altering method interception.