### PR TITLE
Binary logical operators must cast their RHS to boolean

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -105,7 +105,7 @@
   </build>
 
   <properties>
-      <groovy-sandbox.version>1.21</groovy-sandbox.version>
+      <groovy-sandbox.version>1.27</groovy-sandbox.version>
   </properties>
   <dependencies>
     <dependency>

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/LogicalOpBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/LogicalOpBlock.java
@@ -38,17 +38,23 @@ public class LogicalOpBlock implements Block {
             boolean v = DefaultTypeTransformation.castToBoolean(lhs);
             if (and) {
                 if (!v)     return k.receive(false);    // false && ...
-                else        return then(rhs,e,k);
+                else        return then(rhs,e,castRhs);
             } else {
                 if (v)      return k.receive(true);    // true || ...
-                else        return then(rhs,e,k);
+                else        return then(rhs,e,castRhs);
             }
+        }
+
+        public Next castRhs(Object rhs) {
+            boolean v = DefaultTypeTransformation.castToBoolean(rhs);
+            return k.receive(v);
         }
 
         private static final long serialVersionUID = 1L;
     }
 
     static final ContinuationPtr decide = new ContinuationPtr(ContinuationImpl.class,"decide");
+    static final ContinuationPtr castRhs = new ContinuationPtr(ContinuationImpl.class,"castRhs");
 
     private static final long serialVersionUID = 1L;
 }

--- a/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
+++ b/lib/src/test/groovy/com/cloudbees/groovy/cps/CpsTransformerTest.groovy
@@ -438,6 +438,8 @@ class CpsTransformerTest extends AbstractGroovyCpsTest {
         assert evalCPS("true && (false || false)") == false;
         assert evalCPS("true && (true || false)") == true;
         assert evalCPS("false && (true || false)") == false;
+        assert evalCPS("false || 'rhs of || must be cast to boolean'") == true;
+        assert evalCPS("true && 'rhs of && must be cast to boolean'") == true;
         assert evalCPS('''
             x = [0, 0, 0, 0]
             def set(index) {

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <groovy.version>2.4.7</groovy.version>
+        <groovy.version>2.4.21</groovy.version>
         <revision>1.33</revision>
         <changelist>-SNAPSHOT</changelist>
         <!-- TODO: Move these three properties to the parent POM or use org.jenkins-ci:jenkins as the parent POM here -->


### PR DESCRIPTION
I noticed that in CPS-transformed code, `false || x` and `true && x` incorrectly evaluate to `x`. In regular Groovy, these expressions evaluate to `DefaultTypeTransformation.castToBoolean(x)`.