### PR TITLE
[JENKINS-46163] Add support for spread and spread-map operators

### DIFF
--- a/lib/src/main/java/com/cloudbees/groovy/cps/Builder.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/Builder.java
@@ -32,6 +32,8 @@ import com.cloudbees.groovy.cps.impl.PropertyAccessBlock;
 import com.cloudbees.groovy.cps.impl.ReturnBlock;
 import com.cloudbees.groovy.cps.impl.SequenceBlock;
 import com.cloudbees.groovy.cps.impl.SourceLocation;
+import com.cloudbees.groovy.cps.impl.SpreadBlock;
+import com.cloudbees.groovy.cps.impl.SpreadMapBlock;
 import com.cloudbees.groovy.cps.impl.StaticFieldBlock;
 import com.cloudbees.groovy.cps.impl.SuperBlock;
 import com.cloudbees.groovy.cps.impl.SwitchBlock;
@@ -730,6 +732,14 @@ public class Builder {
 
     public Block yield(Object o) {
         return new YieldBlock(o);
+    }
+
+    public Block spread(int line, Block list) {
+        return new SpreadBlock(loc(line), list);
+    }
+
+    public Block spreadMap(int line, Block map) {
+        return new SpreadMapBlock(loc(line), map);
     }
 
     private SourceLocation loc(int line) {

--- a/lib/src/main/java/com/cloudbees/groovy/cps/CpsTransformer.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/CpsTransformer.java
@@ -1278,14 +1278,24 @@ public class CpsTransformer extends CompilationCustomizer implements GroovyCodeV
 
     @Override
     public void visitSpreadExpression(SpreadExpression expression) {
-        sourceUnit.addError(new SyntaxException("spread not yet supported for CPS transformation",
-                expression.getLineNumber(), expression.getColumnNumber()));
+        makeNode("spread", new Runnable() {
+            @Override
+            public void run() {
+                loc(expression);
+                visit(expression.getExpression());
+            }
+        });
     }
 
     @Override
     public void visitSpreadMapExpression(SpreadMapExpression expression) {
-        sourceUnit.addError(new SyntaxException("spread map not yet supported for CPS transformation",
-                expression.getLineNumber(), expression.getColumnNumber()));
+        makeNode("spreadMap", new Runnable() {
+            @Override
+            public void run() {
+                loc(expression);
+                visit(expression.getExpression());
+            }
+        });
     }
 
     @Override

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/FunctionCallBlock.java
@@ -90,11 +90,12 @@ public class FunctionCallBlock extends CallSiteBlockSupport {
             if (args.length>idx)
                 return then(argExps[idx],e,fixArg);
             else {
+                Object[] expandedArgs = SpreadBlock.despreadList(args);
                 if (name.equals("<init>")) {
                     // constructor call
                     Object v;
                     try {
-                        v = e.getInvoker().contextualize(FunctionCallBlock.this).constructorCall((Class)lhs,args);
+                        v = e.getInvoker().contextualize(FunctionCallBlock.this).constructorCall((Class)lhs, expandedArgs);
                     } catch (Throwable t) {
                         if (t instanceof CpsCallableInvocation) {
                             ((CpsCallableInvocation) t).checkMismatch(lhs, Collections.singletonList(name));
@@ -110,7 +111,7 @@ public class FunctionCallBlock extends CallSiteBlockSupport {
                     if (safe && lhs == null) {
                         return k.receive(null);
                     } else {
-                        return methodCall(e, loc, k, FunctionCallBlock.this, lhs, name, args);
+                        return methodCall(e, loc, k, FunctionCallBlock.this, lhs, name, expandedArgs);
                     }
                 }
             }

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/ListBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/ListBlock.java
@@ -15,7 +15,7 @@ public class ListBlock extends CollectionLiteralBlock {
 
     @Override
     protected Object toCollection(Object[] result) {
-        return InvokerHelper.createList(result);
+        return InvokerHelper.createList(SpreadBlock.despreadList(result));
     }
 
     private static final long serialVersionUID = 1L;

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/SpreadBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/SpreadBlock.java
@@ -1,0 +1,108 @@
+package com.cloudbees.groovy.cps.impl;
+
+import com.cloudbees.groovy.cps.Block;
+import com.cloudbees.groovy.cps.Continuation;
+import com.cloudbees.groovy.cps.Env;
+import com.cloudbees.groovy.cps.Next;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.codehaus.groovy.ast.expr.SpreadExpression;
+import org.codehaus.groovy.ast.expr.SpreadMapExpression;
+import org.codehaus.groovy.classgen.AsmClassGenerator;
+import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;
+import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
+
+/**
+ * Handles {@link SpreadExpression} similarly to the way that {@link SpreadMapBlock} handles {@link SpreadMapExpression},
+ * but with a {@code groovy-cps}-specific {@link SpreadList} marker class.
+ *
+ * <p>We use a marker class because we cannot easily mimic the way that Groovy normally handles {@link SpreadExpression}.
+ * To do so, we would need modifications to {@link CpsTransformer} for list and argument list visitors akin to {@link AsmClassGenerator.despreadList},
+ * a new implementation of {@link Block} that would fix those expressions and then call {@link ScriptBytecodeAdapter#despreadList},
+ * and a variant of {@link FunctionCallBlock} that takes a single {@link Block} which is expected to evaluate to {@code Object[]}
+ * (rather than a {@code Block[]}) so that the result of {@code despreadList} can be used directly as the arguments array
+ * for the function call.
+ */
+public class SpreadBlock implements Block {
+    private final SourceLocation loc;
+    private final Block listExp;
+
+    public SpreadBlock(SourceLocation loc, Block listExp) {
+        this.loc = loc;
+        this.listExp = listExp;
+    }
+
+    @Override
+    public Next eval(Env e, Continuation k) {
+        return new ContinuationImpl(e, k).then(listExp, e, fixList);
+    }
+
+    class ContinuationImpl extends ContinuationGroup {
+        private final Env e;
+        private final Continuation k;
+
+        ContinuationImpl(Env e, Continuation k) {
+            this.e = e;
+            this.k = k;
+        }
+
+        public Next fixList(Object value) {
+            try {
+                return k.receive(new SpreadList(despreadList(value).toArray()));
+            } catch (IllegalArgumentException t) {
+                return throwException(e, t, loc, new ReferenceStackTrace());
+            }
+        }
+
+        // c.f. https://github.com/apache/groovy/blob/bd12deac1d73b036d6bae378b69cfdb2cf692490/src/main/java/org/codehaus/groovy/runtime/ScriptBytecodeAdapter.java#L908-L920
+        private List<Object> despreadList(Object value) {
+            if (value == null) {
+                return Collections.singletonList(null);
+            } else if (value instanceof List) {
+                return (List<Object>) value;
+            } else if (value.getClass().isArray()) {
+                return DefaultTypeTransformation.primitiveArrayToList(value);
+            } else {
+                String error = "cannot spread the type " + value.getClass().getName() + " with value " + value;
+                if (value instanceof Map) {
+                    error += ", did you mean to use the spread-map operator instead?";
+                }
+                throw new IllegalArgumentException(error);
+            }
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+
+    /**
+     * Holds the expanded value until it is interpolated into its surrounding context by {@link ListBlock} or {@link FunctionCallBlock}.
+     */
+    static class SpreadList implements Serializable {
+        private final Object[] expanded;
+
+        public SpreadList(Object[] expanded) {
+            this.expanded = expanded;
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+
+    public static Object[] despreadList(Object[] list) {
+        List<Object> expanded = new ArrayList<>();
+        for (Object element : list) {
+            if (element instanceof SpreadList) {
+                Collections.addAll(expanded, ((SpreadList) element).expanded);
+            } else {
+                expanded.add(element);
+            }
+        }
+        return expanded.toArray();
+    }
+
+    static final ContinuationPtr fixList = new ContinuationPtr(ContinuationImpl.class, "fixList");
+
+    private static final long serialVersionUID = 1L;
+}

--- a/lib/src/main/java/com/cloudbees/groovy/cps/impl/SpreadMapBlock.java
+++ b/lib/src/main/java/com/cloudbees/groovy/cps/impl/SpreadMapBlock.java
@@ -1,0 +1,48 @@
+package com.cloudbees.groovy.cps.impl;
+
+import com.cloudbees.groovy.cps.Block;
+import com.cloudbees.groovy.cps.Continuation;
+import com.cloudbees.groovy.cps.Env;
+import com.cloudbees.groovy.cps.Next;
+import groovy.lang.SpreadMapEvaluatingException;
+import org.codehaus.groovy.runtime.InvokerHelper;
+
+public class SpreadMapBlock implements Block {
+    private final SourceLocation loc;
+    private final Block mapExp;
+
+    public SpreadMapBlock(SourceLocation loc, Block mapExp) {
+        this.loc = loc;
+        this.mapExp = mapExp;
+    }
+
+    @Override
+    public Next eval(Env e, Continuation k) {
+        return new ContinuationImpl(e, k).then(mapExp, e, fixMap);
+    }
+
+    class ContinuationImpl extends ContinuationGroup {
+        private final Env e;
+        private final Continuation k;
+
+        ContinuationImpl(Env e, Continuation k) {
+            this.e = e;
+            this.k = k;
+        }
+
+        public Next fixMap(Object value) {
+            try {
+                // Creates a groovy.lang.SpreadMap, which InvokerHelper.createMap (used by MapBlock) handles specially.
+                return k.receive(InvokerHelper.spreadMap(value));
+            } catch (SpreadMapEvaluatingException t) {
+                return throwException(e, t, loc, new ReferenceStackTrace());
+            }
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+
+    static final ContinuationPtr fixMap = new ContinuationPtr(ContinuationImpl.class, "fixMap");
+
+    private static final long serialVersionUID = 1L;
+}

--- a/lib/src/test/java/com/cloudbees/groovy/cps/AbstractGroovyCpsTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/AbstractGroovyCpsTest.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.util.concurrent.atomic.AtomicReference;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
 import org.junit.Before;
@@ -77,20 +78,76 @@ public abstract class AbstractGroovyCpsTest {
         return new CpsTransformer();
     }
 
-    public void assertEvaluate(Object expectedResult, String script) throws Throwable {
-        Object actualCps = evalCPSonly(script);
-        String actualCpsType = GroovyCallSiteSelector.getName(actualCps);
-        String expectedType = GroovyCallSiteSelector.getName(expectedResult);
-        ec.checkThat("CPS-transformed result (" + actualCpsType + ") does not match expected result (" + expectedType + ")", actualCps, equalTo(expectedResult));
-        Object actualNonCps = sh.evaluate(script);
-        String actualNonCpsType = GroovyCallSiteSelector.getName(actualNonCps);
-        ec.checkThat("Non-CPS-transformed result (" + actualNonCpsType + ") does not match expected result (" + expectedType + ")", actualNonCps, equalTo(expectedResult));
+    /**
+     * Use {@code ShouldFail.class} as the expected result for {@link #eval} and similar methods when the expression is expected to throw an exception.
+     */
+    public static final class ShouldFail { }
+
+    @FunctionalInterface
+    public interface ExceptionHandler {
+        public void handleException(Throwable e) throws Exception;
     }
 
-    public Object evalCPS(String script) throws Throwable {
-        Object resultInCps = evalCPSonly(script);
-        ec.checkThat(resultInCps, equalTo(sh.evaluate(script))); // make sure that regular non-CPS execution reports the same result
-        return resultInCps;
+    protected void eval(String script, Object expectedResult, ExceptionHandler handler) {
+        try {
+            Object actual = sh.evaluate(script);
+            String actualType = GroovyCallSiteSelector.getName(actual);
+            String expectedType = GroovyCallSiteSelector.getName(expectedResult);
+            ec.checkThat("Non-CPS-transformed result (" + actualType + ") does not match expected result (" + expectedType + ")", actual, equalTo(expectedResult));
+        } catch (Throwable t) {
+            ec.checkSucceeds(() -> {
+                handler.handleException(t);
+                return null;
+            });
+        }
+    }
+
+    protected void evalCps(String script, Object expectedResult, ExceptionHandler handler) {
+        try {
+            Object actual = parseCps(script).invoke(null, null, Continuation.HALT).run(10000).replay();
+            String actualType = GroovyCallSiteSelector.getName(actual);
+            String expectedType = GroovyCallSiteSelector.getName(expectedResult);
+            ec.checkThat("Non-CPS-transformed result (" + actualType + ") does not match expected result (" + expectedType + ")", actual, equalTo(expectedResult));
+        } catch (Throwable t) {
+            ec.checkSucceeds(() -> {
+                handler.handleException(t);
+                return null;
+            });
+        }
+    }
+
+    /**
+     * Execute a Groovy expression both with and without the CPS transformation and check that the return value matches
+     * the expected value in both cases.
+     * @param expectedReturnValue The expected return value for running the script.
+     * @param script The Groovy script to execute.
+     */
+    public void assertEvaluate(Object expectedReturnValue, String script) {
+        evalCps(script, expectedReturnValue, e -> {
+            throw new RuntimeException("Failed to evaluate sandboxed script: " + script, e);
+        });
+        eval(script, expectedReturnValue, e -> {
+            throw new RuntimeException("Failed to evaluate unsandboxed script: " + script, e);
+        });
+    }
+
+    /**
+     * Execute a Groovy expression both with and without the CPS transformation and check that the script throws an
+     * exception with the same class and message in both cases.
+     * @param expression The Groovy expression to execute.
+     */
+    public void assertFailsWithSameException(String expression) {
+        AtomicReference<Throwable> cpsException = new AtomicReference<>();
+        evalCps(expression, ShouldFail.class, cpsException::set);
+        AtomicReference<Throwable> nonCpsException = new AtomicReference<>();
+        eval(expression, ShouldFail.class, nonCpsException::set);
+        if (cpsException.get() == null || nonCpsException.get() == null) {
+            return; // Either evalCps or eval will have already recorded an error because the result was not ShouldFail.
+        }
+        ec.checkThat("CPS-transformed and non-CPS-transformed exceptions should have the same type",
+                nonCpsException.get().getClass(), equalTo(cpsException.get().getClass()));
+        ec.checkThat("CPS-transformed and non-CPS-transformed exceptions should have the same message",
+                nonCpsException.get().getMessage(), equalTo(cpsException.get().getMessage()));
     }
 
     public Object evalCPSonly(String script) throws Throwable {

--- a/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformerTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformerTest.java
@@ -2,7 +2,6 @@ package com.cloudbees.groovy.cps;
 
 import com.cloudbees.groovy.cps.impl.CpsCallableInvocation;
 import groovy.lang.IntRange;
-import groovy.lang.MissingMethodException;
 import java.io.File;
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -17,11 +16,11 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  *
@@ -322,19 +321,15 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
             "assert true : 'message'\n" +
             "return 3;\n");
 
-        try {
-            evalCPS("assert 1+2 == ((4));");
-            fail();
-        } catch (AssertionError e) {
-            assertThat(e.getMessage(), containsString("1+2 == ((4))"));
-        }
+        evalCps("assert 1+2 == ((4));", ShouldFail.class, t -> {
+            ec.checkThat(t, instanceOf(AssertionError.class));
+            ec.checkThat(t.getMessage(), containsString("1+2 == ((4))"));
+        });
 
-        try {
-            evalCPS("assert (1+2) == 4 : 'with message';");
-            fail();
-        } catch (AssertionError e) {
-            assertThat(e.getMessage(), containsString("with message. Expression: assert (1+2) == 4 : 'with message'"));
-        }
+        evalCps("assert (1+2) == 4 : 'with message';", ShouldFail.class, t -> {
+            ec.checkThat(t, instanceOf(AssertionError.class));
+            ec.checkThat(t.getMessage(), containsString("with message. Expression: assert (1+2) == 4 : 'with message'"));
+        });
     }
 
     @Test
@@ -864,14 +859,14 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
             "return b.size()\n");
 
         String s2 = IntStream.range(0, 251).boxed().map(Object::toString).collect(Collectors.joining(",\n"));
-        try {
-            assertEvaluate(251,
-                "def b = [" + s2 + "]\n" +
-                "return b.size()\n");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(MultipleCompilationErrorsException.class));
-            assertThat(e.getMessage(), containsString("List expressions can only contain up to 250 elements"));
-        }
+        evalCps(
+            "def b = [" + s2 + "]\n" +
+            "return b.size()\n",
+            ShouldFail.class,
+            t -> {
+                assertThat(t, instanceOf(MultipleCompilationErrorsException.class));
+                assertThat(t.getMessage(), containsString("List expressions can only contain up to 250 elements"));
+            });
     }
 
     @Issue("JENKINS-47363")
@@ -882,14 +877,14 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
             "def b = [" + s1 + "]\n" +
             "return b.size()\n");
         String s2 = IntStream.range(0, 126).boxed().map(i -> i + ":" + i).collect(Collectors.joining(",\n"));
-        try {
-            assertEvaluate(126,
-                "def b = [" + s2 + "]\n" +
-                "return b.size()\n");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(MultipleCompilationErrorsException.class));
-            assertThat(e.getMessage(), containsString("Map expressions can only contain up to 125 entries"));
-        }
+        evalCps(
+            "def b = [" + s2 + "]\n" +
+            "return b.size()\n",
+            ShouldFail.class,
+            t -> {
+                assertThat(t, instanceOf(MultipleCompilationErrorsException.class));
+                assertThat(t.getMessage(), containsString("Map expressions can only contain up to 125 entries"));
+            });
     }
 
     @Issue("JENKINS-49679")
@@ -913,32 +908,26 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
 
     @Test
     public void mapEntryInBadContext() throws Throwable {
-        try {
-            evalCPSonly("return [[a: 'a'], [b: 'b'][c: 'c']]");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(MultipleCompilationErrorsException.class));
-            assertThat(e.getMessage(), containsString("Unsupported map entry expression for CPS transformation in this context"));
-        }
+        evalCps("return [[a: 'a'], [b: 'b'][c: 'c']]", ShouldFail.class, e -> {
+            ec.checkThat(e, instanceOf(MultipleCompilationErrorsException.class));
+            ec.checkThat(e.getMessage(), containsString("Unsupported map entry expression for CPS transformation in this context"));
+        });
     }
 
     @Test
     public void spreadMethodCall() throws Throwable {
-        try {
-            evalCPSonly("return ['a', 'b', 'c']*.hashCode()");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(MultipleCompilationErrorsException.class));
-            assertThat(e.getMessage(), containsString("spread not yet supported for CPS transformation"));
-        }
+        evalCps("return ['a', 'b', 'c']*.hashCode()", ShouldFail.class, e -> {
+            ec.checkThat(e, instanceOf(MultipleCompilationErrorsException.class));
+            ec.checkThat(e.getMessage(), containsString("spread not yet supported for CPS transformation"));
+        });
     }
 
     @Test
     public void synchronizedStatement() throws Throwable {
-        try {
-            evalCPSonly("synchronized(this) { return 1 }");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(MultipleCompilationErrorsException.class));
-            assertThat(e.getMessage(), containsString("synchronized is unsupported for CPS transformation"));
-        }
+        evalCps("synchronized(this) { return 1 }", ShouldFail.class, e -> {
+            ec.checkThat(e, instanceOf(MultipleCompilationErrorsException.class));
+            ec.checkThat(e.getMessage(), containsString("synchronized is unsupported for CPS transformation"));
+        });
     }
 
     @Issue("JENKINS-46163")
@@ -969,29 +958,9 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
         assertEvaluate(Collections.singletonList(null),
                 "def x = null\n" +
                 "return [*x]\n");
-    }
-
-    @Issue("JENKINS-46163")
-    @Test public void spreadMapExpression() throws Throwable {
-        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", 3, "d", 4, "e", 5 }),
-            "def x = [a: 1, b: 2, c: 3]\n" +
-            "return [*:x, d: 4, e: 5]\n");
-        assertEvaluate(InvokerHelper.createMap(new Object[] { "d", 4, "a", 1, "b", 2, "c", 3, "e", 5 }),
-            "def x = [a: 1, b: 2, c: 3]\n" +
-            "return [d: 4, *:x, e: 5]\n");
-        assertEvaluate(InvokerHelper.createMap(new Object[] { "d", 4, "e", 5, "a", 1, "b", 2, "c", 3, "e", 5 }),
-            "def x = [a: 1, b: 2, c: 3]\n" +
-            "return [d: 4, e: 5, *:x]\n");
-        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", -1 }),
-            "def x = [a: 1, b: 2, c: 3]\n" +
-            "return [c: 4, *:x, c: -1]\n"); // The final value for a key takes precedence.
-        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", 3 }),
-            "def x = [a: 1, b: 2, c: 3]\n" +
-            "return [*:x]\n");
-        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7 }),
-            "def x = [b: 2, c: 3]\n" +
-            "def y = [e: 5, f: 6]\n" +
-            "return [a: 1, *:x, d: 4, *:y, g: 7]\n");
+        assertFailsWithSameException(
+                "def x = 1\n" +
+                "return *x\n"); // *x cannot exist outside of list literals and method call arguments.
     }
 
     @Issue("JENKINS-46163")
@@ -1026,23 +995,39 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
     }
 
     @Issue("JENKINS-46163")
-    @Test public void spreadMapMethodCallArguments() throws Throwable {
-        assertEvaluate(Collections.singletonMap("a", 1),
-            "def x = [a: 1]\n" +
-            "def id(Map m) { m }\n" +
-            "return id(*:x)\n");
+    @Test public void spreadMapExpression() throws Throwable {
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", 3, "d", 4, "e", 5 }),
+            "def x = [a: 1, b: 2, c: 3]\n" +
+            "return [*:x, d: 4, e: 5]\n");
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "d", 4, "a", 1, "b", 2, "c", 3, "e", 5 }),
+            "def x = [a: 1, b: 2, c: 3]\n" +
+            "return [d: 4, *:x, e: 5]\n");
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "d", 4, "e", 5, "a", 1, "b", 2, "c", 3, "e", 5 }),
+            "def x = [a: 1, b: 2, c: 3]\n" +
+            "return [d: 4, e: 5, *:x]\n");
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", -1 }),
+            "def x = [a: 1, b: 2, c: 3]\n" +
+            "return [c: 4, *:x, c: -1]\n"); // The final value for a key takes precedence.
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", 3 }),
+            "def x = [a: 1, b: 2, c: 3]\n" +
+            "return [*:x]\n");
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7 }),
+            "def x = [b: 2, c: 3]\n" +
+            "def y = [e: 5, f: 6]\n" +
+            "return [a: 1, *:x, d: 4, *:y, g: 7]\n");
+        // When used in method call arguments, *:map is the same as map, except for creating an instance of SpreadMap.
+        // IDK why Groovy even allows the spread syntax here.
         assertEvaluate(Collections.singletonMap("a", 1),
             "def x = [a: 1]\n" +
             "def id(def m) { m }\n" +
             "return id(*:x)\n");
-        ec.checkThrows(MissingMethodException.class, () -> evalCPSonly(
-                "def x = [a: 1]\n" +
-                "def id(String a, int i) { [a, i] }\n" +
-                "return id(*:x)\n"));
-        ec.checkThrows(MissingMethodException.class, () -> getSh().evaluate(
-                "def x = [a: 1]\n" +
-                "def id(String a, int i) { [a, i] }\n" +
-                "return id(*:x)\n"));
+        assertFailsWithSameException(
+            "def x = [a: 1]\n" +
+            "def id(String a, int i) { [a, i] }\n" +
+            "return id(*:x)\n");
+        assertFailsWithSameException(
+            "def x = [a: 1]\n" +
+            "return *:x\n"); // *:x is syntactically invalid outside of map literals and method call arguments.
     }
 
     @Test
@@ -1074,7 +1059,7 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
     }
 
     @Test public void voidMethodsWithInitialExpressionsAreExpandedToCorrectOverloads() throws Throwable {
-        assertEquals(Arrays.asList("abc", "xbc", "xyc", "xyz"), evalCPS(
+        assertEvaluate(Arrays.asList("abc", "xbc", "xyc", "xyz"),
                 "import groovy.transform.Field\n" +
                 "@Field def r = []\n" +
                 "void m2(a = 'a', b = 'b', c = 'c') {\n" +
@@ -1084,8 +1069,8 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
                 "m2('x')\n" +
                 "m2('x', 'y')\n" +
                 "m2('x', 'y', 'z')\n" +
-                "r"));
-        assertEquals(Arrays.asList("abc", "xbc", "xby"), evalCPS(
+                "r");
+        assertEvaluate(Arrays.asList("abc", "xbc", "xby"),
                 "import groovy.transform.Field\n" +
                 "@Field def r = []\n" +
                 "void m2(a = 'a', b, c = 'c') {\n" +
@@ -1094,18 +1079,15 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
                 "m2('b')\n" +
                 "m2('x', 'b')\n" +
                 "m2('x', 'b', 'y')\n" +
-                "r"));
+                "r");
     }
 
     @Issue("JENKINS-57253")
     @Test public void illegalBreakStatement() throws Throwable {
         getBinding().setProperty("sentinel", 1);
-        try {
-            evalCPSonly("sentinel = 2; break;");
-            fail("Execution should fail");
-        } catch (Exception e) {
+        evalCps("sentinel = 2; break;", ShouldFail.class, e -> {
             assertThat(e.toString(), containsString("the break statement is only allowed inside loops or switches"));
-        }
+        });
         assertEquals("Script should fail during compilation", 1, getBinding().getProperty("sentinel"));
     }
 
@@ -1165,8 +1147,7 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
                 "t as Boolean\n" +
                 "t.auditLog");
         // asBoolean CPS (has never worked, still does not work)
-        try {
-            evalCPS(
+        evalCps(
                 "class Test {\n" +
                 "  def auditLog = []\n" +
                 "  def asBoolean() {\n" +
@@ -1175,11 +1156,11 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
                 "}\n" +
                 "def t = new Test()\n" +
                 "(Boolean)t\n" +
-                "t.auditLog");
-            fail("Should have thrown an exception");
-        } catch (Throwable t) {
-            assertEquals("java.lang.IllegalStateException: Test.asBoolean must be @NonCPS; see: https://jenkins.io/redirect/pipeline-cps-method-mismatches/", t.toString());
-        }
+                "t.auditLog",
+                ShouldFail.class,
+                t -> {
+                    ec.checkThat(t.toString(), equalTo("java.lang.IllegalStateException: Test.asBoolean must be @NonCPS; see: https://jenkins.io/redirect/pipeline-cps-method-mismatches/"));
+                });
         // asBoolean NonCPS (required)
         assertEvaluate(Collections.singletonList("asBoolean"),
                 "class Test {\n" +

--- a/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformerTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/CpsTransformerTest.java
@@ -2,6 +2,7 @@ package com.cloudbees.groovy.cps;
 
 import com.cloudbees.groovy.cps.impl.CpsCallableInvocation;
 import groovy.lang.IntRange;
+import groovy.lang.MissingMethodException;
 import java.io.File;
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -10,6 +11,7 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
+import org.codehaus.groovy.runtime.InvokerHelper;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -939,28 +941,108 @@ public class CpsTransformerTest extends AbstractGroovyCpsTest {
         }
     }
 
-    @Test
-    public void spreadExpression() throws Throwable {
-        try {
-            evalCPSonly(
-                "def x = [1, 2, 3]\n" +
+    @Issue("JENKINS-46163")
+    @Test public void spreadExpression() throws Throwable {
+        String[] declarations = new String[] {
+            "def", // ArrayList
+            "Object[]", // Object array
+            "int[]" // Primitive array
+        };
+        for (String decl : declarations) {
+            assertEvaluate(Arrays.asList(1, 2, 3, 4, 5),
+                decl + " x = [1, 2, 3]\n" +
                 "return [*x, 4, 5]\n");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(MultipleCompilationErrorsException.class));
-            assertThat(e.getMessage(), containsString("spread not yet supported for CPS transformation"));
+            assertEvaluate(Arrays.asList(4, 1, 2, 3, 5),
+                decl + " x = [1, 2, 3]\n" +
+                "return [4, *x, 5]\n");
+            assertEvaluate(Arrays.asList(4, 5, 1, 2, 3),
+                decl + " x = [1, 2, 3]\n" +
+                "return [4, 5, *x]\n");
+            assertEvaluate(Arrays.asList(1, 2, 3),
+                decl + " x = [1, 2, 3]\n" +
+                "return [*x]\n");
+            assertEvaluate(Arrays.asList(1, 2, 3, 4, 5, 6, 7),
+                decl + " x = [2, 3]\n" +
+                decl + " y = [5, 6]\n" +
+                "return [1, *x, 4, *y, 7]\n");
         }
+        assertEvaluate(Collections.singletonList(null),
+                "def x = null\n" +
+                "return [*x]\n");
     }
 
-    @Test
-    public void spreadMapExpression() throws Throwable {
-        try {
-            evalCPSonly(
-                "def x = [a: 1, b: 2, c: 3]\n" +
-                "return [*:x, d: 4, e: 5]\n");
-        } catch (Exception e) {
-            assertThat(e, instanceOf(MultipleCompilationErrorsException.class));
-            assertThat(e.getMessage(), containsString("spread map not yet supported for CPS transformation"));
+    @Issue("JENKINS-46163")
+    @Test public void spreadMapExpression() throws Throwable {
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", 3, "d", 4, "e", 5 }),
+            "def x = [a: 1, b: 2, c: 3]\n" +
+            "return [*:x, d: 4, e: 5]\n");
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "d", 4, "a", 1, "b", 2, "c", 3, "e", 5 }),
+            "def x = [a: 1, b: 2, c: 3]\n" +
+            "return [d: 4, *:x, e: 5]\n");
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "d", 4, "e", 5, "a", 1, "b", 2, "c", 3, "e", 5 }),
+            "def x = [a: 1, b: 2, c: 3]\n" +
+            "return [d: 4, e: 5, *:x]\n");
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", -1 }),
+            "def x = [a: 1, b: 2, c: 3]\n" +
+            "return [c: 4, *:x, c: -1]\n"); // The final value for a key takes precedence.
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", 3 }),
+            "def x = [a: 1, b: 2, c: 3]\n" +
+            "return [*:x]\n");
+        assertEvaluate(InvokerHelper.createMap(new Object[] { "a", 1, "b", 2, "c", 3, "d", 4, "e", 5, "f", 6, "g", 7 }),
+            "def x = [b: 2, c: 3]\n" +
+            "def y = [e: 5, f: 6]\n" +
+            "return [a: 1, *:x, d: 4, *:y, g: 7]\n");
+    }
+
+    @Issue("JENKINS-46163")
+    @Test public void spreadMethodCallArguments() throws Throwable {
+        String[] declarations = new String[] {
+            "def", // ArrayList
+            "Object[]", // Object array
+            "int[]" // Primitive array
+        };
+        for (String decl : declarations) {
+            assertEvaluate(Arrays.asList(1, 2, 3),
+                decl + " x = [1, 2, 3]\n" +
+                "def id(a, b, c) { [a, b, c] }\n" +
+                "return id(*x)\n");
+            assertEvaluate(Arrays.asList(1, 2, 3),
+                decl + " x = [2, 3]\n" +
+                "def id(a, b, c) { [a, b, c] }\n" +
+                "return id(1, *x)\n");
+            assertEvaluate(Arrays.asList(1, 2, 3),
+                decl + " x = [1, 2]\n" +
+                "def id(a, b, c) { [a, b, c] }\n" +
+                "return id(*x, 3)\n");
+            assertEvaluate(Arrays.asList(1, 2, 3),
+                decl + " x = [2]\n" +
+                "def id(a, b, c) { [a, b, c] }\n" +
+                "return id(1, *x, 3)\n");
         }
+        assertEvaluate(Arrays.asList(1, null, 3),
+                "def x = null\n" +
+                "def id(a, b, c) { [a, b, c] }\n" +
+                "return id(1, *x, 3)\n");
+    }
+
+    @Issue("JENKINS-46163")
+    @Test public void spreadMapMethodCallArguments() throws Throwable {
+        assertEvaluate(Collections.singletonMap("a", 1),
+            "def x = [a: 1]\n" +
+            "def id(Map m) { m }\n" +
+            "return id(*:x)\n");
+        assertEvaluate(Collections.singletonMap("a", 1),
+            "def x = [a: 1]\n" +
+            "def id(def m) { m }\n" +
+            "return id(*:x)\n");
+        ec.checkThrows(MissingMethodException.class, () -> evalCPSonly(
+                "def x = [a: 1]\n" +
+                "def id(String a, int i) { [a, i] }\n" +
+                "return id(*:x)\n"));
+        ec.checkThrows(MissingMethodException.class, () -> getSh().evaluate(
+                "def x = [a: 1]\n" +
+                "def id(String a, int i) { [a, i] }\n" +
+                "return id(*:x)\n"));
     }
 
     @Test

--- a/lib/src/test/java/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.java
+++ b/lib/src/test/java/com/cloudbees/groovy/cps/sandbox/SandboxInvokerTest.java
@@ -31,9 +31,7 @@ import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 import org.codehaus.groovy.runtime.ProxyGeneratorAdapter;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ErrorCollector;
 import org.jvnet.hudson.test.Issue;
 import org.kohsuke.groovy.sandbox.ClassRecorder;
 import org.kohsuke.groovy.sandbox.impl.GroovyCallSiteSelector;
@@ -43,12 +41,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class SandboxInvokerTest extends AbstractGroovyCpsTest {
-    @Rule
-    public ErrorCollector ec = new ErrorCollector();
-
     ClassRecorder cr = new ClassRecorder();
 
     @Override
@@ -60,24 +54,42 @@ public class SandboxInvokerTest extends AbstractGroovyCpsTest {
         CpsTransformer.iota.set(0);
     }
 
-    protected Object evalCpsSandbox(String script) throws Throwable {
-        FunctionCallEnv e = (FunctionCallEnv)Envs.empty();
-        e.setInvoker(new SandboxInvoker());
+    private void evalCpsSandbox(String expression, Object expectedResult, ExceptionHandler handler) {
+        FunctionCallEnv env = (FunctionCallEnv)Envs.empty();
+        env.setInvoker(new SandboxInvoker());
 
         cr.reset();
         cr.register();
         try {
-            return parseCps(script).invoke(e, null, Continuation.HALT).run().yield.replay();
+            Object actual = parseCps(expression).invoke(env, null, Continuation.HALT).run().yield.replay();
+            String actualType = GroovyCallSiteSelector.getName(actual);
+            String expectedType = GroovyCallSiteSelector.getName(expectedResult);
+            ec.checkThat("CPS and sandbox-transformed result (" + actualType + ") does not match expected result (" + expectedType + ")", actual, equalTo(expectedResult));
+        } catch (Throwable t) {
+            ec.checkSucceeds(() -> {
+                try {
+                    handler.handleException(t);
+                } catch (Throwable t2) {
+                    t2.addSuppressed(t); // Keep the original error around in case an assertion fails in the handler.
+                    throw t2;
+                }
+                return null;
+            });
         } finally {
             cr.unregister();
         }
     }
 
+    @Override
+    public void assertEvaluate(Object expectedReturnValue, String script) {
+        evalCpsSandbox(script, expectedReturnValue, e -> {
+            throw new RuntimeException("Failed to evaluate CPS and sandboxed-transformed script: " + script, e);
+        });
+        // TODO: Refactor things so we can check evalCps as well.
+    }
+
     public void assertIntercept(String script, Object expectedResult, String... expectedInterceptions) throws Throwable {
-        Object actualResult = evalCpsSandbox(script);
-        String actualCpsType = GroovyCallSiteSelector.getName(actualResult);
-        String expectedType = GroovyCallSiteSelector.getName(expectedResult);
-        ec.checkThat("CPS and sandbox-transformed result (" + actualCpsType + ") does not match expected result (" + expectedType + ")", actualResult, equalTo(expectedResult));
+        assertEvaluate(expectedResult, script);
         ec.checkThat(cr.toString().split("\n"), equalTo(expectedInterceptions));
     }
 
@@ -440,7 +452,7 @@ public class SandboxInvokerTest extends AbstractGroovyCpsTest {
             "ArrayList[Integer]",
             "ArrayList[Integer]",
             "String.plus(String)",
-            "String.plus(String)", 
+            "String.plus(String)",
             "String.plus(String)");
     }
 
@@ -509,29 +521,27 @@ public class SandboxInvokerTest extends AbstractGroovyCpsTest {
     @Issue("SECURITY-1186")
     @Test
     public void finalizerForbidden() throws Throwable {
-        try {
-            evalCpsSandbox("class Test { @Override public void finalize() { } }; null");
-            fail("Finalizers should be rejected");
-        } catch (MultipleCompilationErrorsException e) {
+        evalCpsSandbox("class Test { @Override public void finalize() { } }; null", ShouldFail.class, t -> {
+            assertThat(t, instanceOf(MultipleCompilationErrorsException.class));
+            MultipleCompilationErrorsException e = (MultipleCompilationErrorsException) t;
             assertThat(e.getErrorCollector().getErrorCount(), equalTo(1));
             Exception innerE = e.getErrorCollector().getException(0);
             assertThat(innerE, instanceOf(SecurityException.class));
             assertThat(innerE.getMessage(), containsString("Object.finalize()"));
-        }
+        });
     }
 
     @Issue("SECURITY-1186")
     @Test
     public void nonCpsfinalizerForbidden() throws Throwable {
-        try {
-            evalCpsSandbox("class Test { @Override @NonCPS public void finalize() { } }; null");
-            fail("Finalizers should be rejected");
-        } catch (MultipleCompilationErrorsException e) {
+        evalCpsSandbox("class Test { @Override @NonCPS public void finalize() { } }; null", ShouldFail.class, t -> {
+            assertThat(t, instanceOf(MultipleCompilationErrorsException.class));
+            MultipleCompilationErrorsException e = (MultipleCompilationErrorsException) t;
             assertThat(e.getErrorCollector().getErrorCount(), equalTo(1));
             Exception innerE = e.getErrorCollector().getException(0);
             assertThat(innerE, instanceOf(SecurityException.class));
             assertThat(innerE.getMessage(), containsString("Object.finalize()"));
-        }
+        });
     }
 
     @Issue("SECURITY-1710")
@@ -587,15 +597,14 @@ public class SandboxInvokerTest extends AbstractGroovyCpsTest {
         // Regular Groovy casts the rhs of array assignments to match the component type of the array, but the
         // sandbox does not do this (with or without the CPS transformation). Ideally the sandbox would have the same
         // behavior as regular Groovy, but the current behavior is safe, which is good enough.
-        try {
-            evalCpsSandbox(
-                "File[] files = [null]\n" +
-                "files[0] = ['secret.key']\n " +
-                "files[0]");
-            fail("The sandbox must intercept unsafe array element assignments");
-        } catch (Throwable t) {
-            assertEquals("java.lang.ArrayStoreException: java.util.ArrayList", t.toString());
-        }
+        evalCpsSandbox(
+            "File[] files = [null]\n" +
+            "files[0] = ['secret.key']\n " +
+            "files[0]",
+            ShouldFail.class,
+            t -> {
+                assertEquals("java.lang.ArrayStoreException: java.util.ArrayList", t.toString());
+            });
     }
 
     @Issue("SECURITY-2824")


### PR DESCRIPTION
See [JENKINS-46163](https://issues.jenkins.io/browse/JENKINS-46163). This PR is based on #116.

We follow the same approach as regular Groovy for `SpreadMapExpression` (the expression gets turned into a special `SpreadMap` by [`InvokerHelper.spreadMap`](https://github.com/apache/groovy/blob/41b990d0a20e442f29247f0e04cbed900f3dcad4/src/main/org/codehaus/groovy/runtime/InvokerHelper.java#L378), and then Map literals are constructed using [`InvokerHelper.createMap`](https://github.com/apache/groovy/blob/41b990d0a20e442f29247f0e04cbed900f3dcad4/src/main/org/codehaus/groovy/runtime/InvokerHelper.java#L399) which detects this marker class and interpolates it).

We use a similar approach for `SpreadExpression`, but this is not the approach that Groovy itself uses. Some reasoning behind this choice is given in the Javadoc for `SpreadBlock`.

This PR also includes various improvements to the test harness which have been copied from `groovy-sandbox`. I used them in the new tests and adapted existing tests to use the new assertion methods. The two commits can be reviewed independently.